### PR TITLE
✨ Add measurements to mapped circuit

### DIFF
--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -39,6 +39,12 @@ void ExactMapper::map(const Configuration& settings) {
         results.time    = static_cast<std::chrono::duration<double>>(std::chrono::high_resolution_clock::now() - start).count();
         results.timeout = false;
         qcMapped        = qc.clone();
+
+        // unify quantum registers
+        qcMapped.unifyQuantumRegisters();
+
+        // append measurements according to output permutation
+        qcMapped.appendMeasurementsAccordingToOutputPermutation();
         return;
     }
 
@@ -266,6 +272,12 @@ void ExactMapper::map(const Configuration& settings) {
             ++layerIterator;
         }
     }
+
+    // unify quantum registers
+    qcMapped.unifyQuantumRegisters();
+
+    // append measurements according to output permutation
+    qcMapped.appendMeasurementsAccordingToOutputPermutation();
 
     auto                          end  = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> diff = end - start;

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -174,6 +174,12 @@ void HeuristicMapper::map(const Configuration& ms) {
         }
     }
 
+    // unify quantum registers
+    qcMapped.unifyQuantumRegisters();
+
+    // append measurements according to output permutation
+    qcMapped.appendMeasurementsAccordingToOutputPermutation();
+
     const auto                    end  = std::chrono::steady_clock::now();
     std::chrono::duration<double> diff = end - start;
     results.time                       = diff.count();


### PR DESCRIPTION
This PR adds the functionality to include measurements in mapped circuits according to the stored output permutation.
Furthermore, the qubit registers of the mapped circuit are now unified into a single register, similar to how this is handled in Qiskit.