### PR TITLE
✨ add option to dump WCNF file from exact mapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,15 +46,21 @@ jobs:
       - name: Install Z3
         run:  python -m pip install z3-solver
 
+      - name: Explore where python is installed
+        run:  |
+              echo $pythonLocation
+              ls -a $pythonLocation
+              ls -a $pythonLocation/lib
+
       - name: Configure CMake
-        run: |
-             export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/python/cp310-cp310/lib/python3.10/site-packages/z3/lib 
-             export Z3_ROOT=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3 
-             export Z3_DIR=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3
-             cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QMAP_TESTS=ON -DBINDINGS=ON
+        run:  |
+              export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/python/cp310-cp310/lib/python3.10/site-packages/z3/lib 
+              export Z3_ROOT=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3 
+              export Z3_DIR=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3
+              cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QMAP_TESTS=ON -DBINDINGS=ON
 
       - name: Build
-        run: |
+        run:  |
           cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_heuristic
           cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_exact
           cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_heuristic_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,18 +46,12 @@ jobs:
       - name: Install Z3
         run:  python -m pip install z3-solver
 
-      - name: Explore where python is installed
-        run:  |
-              echo $pythonLocation
-              ls -a $pythonLocation
-              ls -a $pythonLocation/lib
-
       - name: Configure CMake
-        run:  |
-              export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/python/cp310-cp310/lib/python3.10/site-packages/z3/lib 
-              export Z3_ROOT=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3 
-              export Z3_DIR=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3
-              cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QMAP_TESTS=ON -DBINDINGS=ON
+        run: |
+             export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$pythonLocation/lib/python3.10/site-packages/z3/lib 
+             export Z3_ROOT=$pythonLocation/lib/python3.10/site-packages/z3 
+             export Z3_DIR=$pythonLocation/lib/python3.10/site-packages/z3
+             cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QMAP_TESTS=ON -DBINDINGS=ON
 
       - name: Build
         run:  |
@@ -72,9 +66,9 @@ jobs:
 
       - name: Coverage
         run: |
-             export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/python/cp310-cp310/lib/python3.10/site-packages/z3/lib 
-             export Z3_ROOT=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3 
-             export Z3_DIR=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3
+             export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$pythonLocation/lib/python3.10/site-packages/z3/lib 
+             export Z3_ROOT=$pythonLocation/lib/python3.10/site-packages/z3 
+             export Z3_DIR=$pythonLocation/lib/python3.10/site-packages/z3
              cmake -S "${{github.workspace}}" -B "${{github.workspace}}/buildCov" -DCMAKE_BUILD_TYPE=Debug -DBUILD_QMAP_TESTS=ON -DCOVERAGE=ON -DBINDINGS=ON
              cmake --build "${{github.workspace}}/buildCov" --config Debug --target qmap_exact_test
              cmake --build "${{github.workspace}}/buildCov" --config Debug --target qmap_heuristic_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-             export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/python/cp39-cp39/lib/python3.9/site-packages/z3/lib 
+             export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/python/cp310-cp310/lib/python3.10/site-packages/z3/lib 
              export Z3_ROOT=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3 
              export Z3_DIR=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3
              cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QMAP_TESTS=ON -DBINDINGS=ON
@@ -66,7 +66,7 @@ jobs:
 
       - name: Coverage
         run: |
-             export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/python/cp39-cp39/lib/python3.9/site-packages/z3/lib 
+             export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/python/cp310-cp310/lib/python3.10/site-packages/z3/lib 
              export Z3_ROOT=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3 
              export Z3_DIR=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3
              cmake -S "${{github.workspace}}" -B "${{github.workspace}}/buildCov" -DCMAKE_BUILD_TYPE=Debug -DBUILD_QMAP_TESTS=ON -DCOVERAGE=ON -DBINDINGS=ON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Configure CMake
         run: |
              export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/python/cp39-cp39/lib/python3.9/site-packages/z3/lib 
-             export Z3_ROOT=/opt/python/cp39-cp39/lib/python3.9/site-packages/z3 
-             export Z3_DIR=/opt/python/cp39-cp39/lib/python3.9/site-packages/z3
+             export Z3_ROOT=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3 
+             export Z3_DIR=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3
              cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QMAP_TESTS=ON -DBINDINGS=ON
 
       - name: Build
@@ -65,15 +65,15 @@ jobs:
         run: ctest -C $BUILD_TYPE --output-on-failure
 
       - name: Coverage
-        run:  |
-              export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/python/cp39-cp39/lib/python3.9/site-packages/z3/lib 
-              export Z3_ROOT=/opt/python/cp39-cp39/lib/python3.9/site-packages/z3 
-              export Z3_DIR=/opt/python/cp39-cp39/lib/python3.9/site-packages/z3
-              cmake -S "${{github.workspace}}" -B "${{github.workspace}}/buildCov" -DCMAKE_BUILD_TYPE=Debug -DBUILD_QMAP_TESTS=ON -DCOVERAGE=ON -DBINDINGS=ON
-              cmake --build "${{github.workspace}}/buildCov" --config Debug --target qmap_exact_test
-              cmake --build "${{github.workspace}}/buildCov" --config Debug --target qmap_heuristic_test
-              cd buildCov/test
-              ctest -C $BUILD_TYPE --output-on-failure
+        run: |
+             export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/python/cp39-cp39/lib/python3.9/site-packages/z3/lib 
+             export Z3_ROOT=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3 
+             export Z3_DIR=/opt/python/cp310-cp310/lib/python3.10/site-packages/z3
+             cmake -S "${{github.workspace}}" -B "${{github.workspace}}/buildCov" -DCMAKE_BUILD_TYPE=Debug -DBUILD_QMAP_TESTS=ON -DCOVERAGE=ON -DBINDINGS=ON
+             cmake --build "${{github.workspace}}/buildCov" --config Debug --target qmap_exact_test
+             cmake --build "${{github.workspace}}/buildCov" --config Debug --target qmap_heuristic_test
+             cd buildCov/test
+             ctest -C $BUILD_TYPE --output-on-failure
       - name: Run gcov
         run:  |
               find . -type f -name '*.gcno' -exec gcov -p  {} +

--- a/include/MappingResults.hpp
+++ b/include/MappingResults.hpp
@@ -39,6 +39,8 @@ struct MappingResults {
     CircuitInfo output{};
     std::string mappedCircuit{};
 
+    std::string wcnf{};
+
     MappingResults()          = default;
     virtual ~MappingResults() = default;
 
@@ -47,6 +49,7 @@ struct MappingResults {
         architecture = mappingResults.architecture;
         config       = mappingResults.config;
         output       = mappingResults.output;
+        wcnf         = mappingResults.wcnf;
     }
 
     [[nodiscard]] std::string toString() const {

--- a/include/configuration/Configuration.hpp
+++ b/include/configuration/Configuration.hpp
@@ -53,6 +53,9 @@ struct Configuration {
     // use qubit subsets in exact mapper
     bool useSubsets = true;
 
+    // include WCNF file in results of exact mapper
+    bool includeWCNF = false;
+
     // limit the number of considered swaps
     bool          enableSwapLimits = true;
     SwapReduction swapReduction    = SwapReduction::CouplingLimit;
@@ -91,7 +94,8 @@ struct Configuration {
             if (encoding == Encoding::Commander || encoding == Encoding::Bimander) {
                 exact["commander_grouping"] = ::toString(commanderGrouping);
             }
-            exact["use_subsets"] = useSubsets;
+            exact["include_WCNF"] = includeWCNF;
+            exact["use_subsets"]  = useSubsets;
             if (enableSwapLimits) {
                 auto& limits             = exact["limits"];
                 limits["swap_reduction"] = ::toString(swapReduction);

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -177,6 +177,7 @@ PYBIND11_MODULE(pyqmap, m) {
             .def_readwrite("encoding", &Configuration::encoding)
             .def_readwrite("commander_grouping", &Configuration::commanderGrouping)
             .def_readwrite("use_subsets", &Configuration::useSubsets)
+            .def_readwrite("include_WCNF", &Configuration::includeWCNF)
             .def_readwrite("enable_limits", &Configuration::enableSwapLimits)
             .def_readwrite("swap_reduction", &Configuration::swapReduction)
             .def_readwrite("swap_limit", &Configuration::swapLimit)
@@ -193,6 +194,7 @@ PYBIND11_MODULE(pyqmap, m) {
             .def_readwrite("time", &MappingResults::time)
             .def_readwrite("timeout", &MappingResults::timeout)
             .def_readwrite("mapped_circuit", &MappingResults::mappedCircuit)
+            .def_readwrite("wcnf", &MappingResults::wcnf)
             .def("json", &MappingResults::json)
             .def("csv", &MappingResults::csv)
             .def("__repr__", &MappingResults::toString);

--- a/mqt/qmap/compile.py
+++ b/mqt/qmap/compile.py
@@ -21,6 +21,7 @@ def compile(circ, arch: Union[str, Arch],
             use_bdd: bool = False,
             swap_reduction: Union[str, SwapReduction] = "coupling_limit",
             swap_limit: int = 0,
+            include_WCNF: bool = False,
             use_subsets: bool = True,
             verbose: bool = False
             ) -> MappingResults:
@@ -45,6 +46,8 @@ def compile(circ, arch: Union[str, Arch],
     :type swap_reduction: Union[str, SwapReduction]
     :param swap_limit - Set a custom limit for max swaps per layer, for the increasing reduction strategy it sets the max swaps per layer
     :type swap_limit: int
+    :param include_WCNF: Include WCNF file in the results (default: False)
+    :type include_WCNF: bool
     :param use_subsets: Use qubit subsets, or consider all available physical qubits at once (default: True)
     :type use_subsets: bool
     :param use_teleportation:  Use teleportation in addition to swaps
@@ -69,6 +72,7 @@ def compile(circ, arch: Union[str, Arch],
     config.swap_reduction = SwapReduction(swap_reduction)
     config.swap_limit = swap_limit
     config.use_bdd = use_bdd
+    config.include_WCNF = include_WCNF
     config.use_subsets = use_subsets
     config.use_teleportation = use_teleportation
     config.teleportation_fake = teleportation_fake

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -375,6 +375,7 @@ void ExactMapper::coreMappingRoutine(const std::set<unsigned short>& qubitChoice
     params   p(c);
     p.set("timeout", timeout);
     p.set("pb.compile_equality", true);
+    p.set("pp.wcnf", true);
     p.set("maxres.hill_climb", true);
     p.set("maxres.pivot_on_correction_set", false);
     opt.set(p);
@@ -609,6 +610,12 @@ void ExactMapper::coreMappingRoutine(const std::set<unsigned short>& qubitChoice
                 opt.add(reverse.simplify(), GATES_OF_DIRECTION_REVERSE);
             }
         }
+    }
+
+    if (config.includeWCNF) {
+        std::stringstream ss{};
+        ss << opt;
+        choiceResults.wcnf = ss.str();
     }
 
     //////////////////////////////////////////

--- a/test/test_exact.cpp
+++ b/test/test_exact.cpp
@@ -32,6 +32,7 @@ protected:
         IBMQ_London.loadCalibrationData(test_calibration_dir + "ibmq_london.csv");
         IBM_QX4.loadCouplingMap(AvailableArchitecture::IBM_QX4);
         settings.verbose = true;
+        settings.method  = Method::Exact;
     }
 };
 

--- a/test/test_exact.cpp
+++ b/test/test_exact.cpp
@@ -32,7 +32,6 @@ protected:
         IBMQ_London.loadCalibrationData(test_calibration_dir + "ibmq_london.csv");
         IBM_QX4.loadCouplingMap(AvailableArchitecture::IBM_QX4);
         settings.verbose = true;
-        settings.method  = Method::Exact;
     }
 };
 

--- a/test/test_exact.cpp
+++ b/test/test_exact.cpp
@@ -32,6 +32,7 @@ protected:
         IBMQ_London.loadCalibrationData(test_calibration_dir + "ibmq_london.csv");
         IBM_QX4.loadCouplingMap(AvailableArchitecture::IBM_QX4);
         settings.verbose = true;
+        settings.method  = Method::Exact;
     }
 };
 
@@ -388,4 +389,20 @@ TEST_F(ExactTest, MapToSubsetNotIncludingQ0) {
     EXPECT_EQ(qcMapped.initialLayout[0], 3);
     EXPECT_EQ(qcMapped.outputPermutation.size(), 3U);
     EXPECT_TRUE(qcMapped.garbage.at(3));
+}
+
+TEST_F(ExactTest, WCNF) {
+    using namespace dd::literals;
+
+    qc.addQubitRegister(3U);
+    qc.x(0, 1_pc);
+    qc.x(1, 2_pc);
+    qc.x(2, 0_pc);
+
+    settings.verbose     = false;
+    settings.includeWCNF = true;
+    IBMQ_London_mapper.map(settings);
+    const auto& wcnf = IBMQ_London_mapper.getResults().wcnf;
+    std::cout << wcnf << std::endl;
+    EXPECT_TRUE(!wcnf.empty());
 }


### PR DESCRIPTION
This PR adds the option to dump a WCNF file for the instances generated by the exact mapper as exposed by Z3.

Note that it seems that this functionality does not always work as intended from the Z3 side, since the output sometimes stays empty. I assume that this is due to an error being thrown in the library code of Z3 that is caught and not properly propagated. Might be worth to open an issue at their repository.