### PR TITLE
⚡ Early termination in permutation search

### DIFF
--- a/include/Architecture.hpp
+++ b/include/Architecture.hpp
@@ -129,7 +129,7 @@ public:
         }
     }
 
-    unsigned long minimumNumberOfSwaps(std::vector<unsigned short>& permutation);
+    unsigned long minimumNumberOfSwaps(std::vector<unsigned short>& permutation, long limit = -1);
     void          minimumNumberOfSwaps(std::vector<unsigned short>& permutation, std::vector<std::pair<unsigned short, unsigned short>>& swaps);
 
     struct Node {

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -152,7 +152,9 @@ void Architecture::createFidelityTable() {
     }
 }
 
-unsigned long Architecture::minimumNumberOfSwaps(std::vector<unsigned short>& permutation) {
+unsigned long Architecture::minimumNumberOfSwaps(std::vector<unsigned short>& permutation, long limit) {
+    bool tryToAbortEarly = (limit != -1);
+
     // consolidate used qubits
     std::set<unsigned short> qubits{};
     for (const auto& q: permutation) {
@@ -201,6 +203,11 @@ unsigned long Architecture::minimumNumberOfSwaps(std::vector<unsigned short>& pe
     while (!queue.empty()) {
         Node current = queue.top();
         queue.pop();
+
+        // in case no solution has been found using less than `limit` swaps, search can be aborted
+        if (tryToAbortEarly && current.nswaps >= static_cast<unsigned long>(limit)) {
+            return limit + 1U;
+        }
 
         for (const auto& swap: possibleSwaps) {
             Node next = current;

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -340,7 +340,7 @@ void ExactMapper::coreMappingRoutine(const std::set<unsigned short>& qubitChoice
     //////////////////////////////////////////
     if (config.enableSwapLimits && !config.useBDD) {
         do {
-            auto picost = architecture.minimumNumberOfSwaps(pi);
+            auto picost = architecture.minimumNumberOfSwaps(pi, static_cast<long>(limit));
             if (picost > limit) {
                 skipped_pi.insert(piCount);
             }


### PR DESCRIPTION
This PR significantly reduces the runtime spent in the exact mapper for computing the permutations that need to be considered given a coupling limit by terminating early.