### PR TITLE
✨ Pre- and Post-Mapping Optimizations

### DIFF
--- a/include/Mapper.hpp
+++ b/include/Mapper.hpp
@@ -42,8 +42,8 @@ protected:
         }
     };
 
-    qc::QuantumComputation& qc;
-    Architecture&           architecture;
+    qc::QuantumComputation qc;
+    Architecture&          architecture;
 
     qc::QuantumComputation         qcMapped;
     std::vector<std::vector<Gate>> layers{};
@@ -66,7 +66,7 @@ protected:
     virtual void finalizeMappedCircuit();
 
 public:
-    Mapper(qc::QuantumComputation& qc, Architecture& architecture);
+    Mapper(const qc::QuantumComputation& qc, Architecture& architecture);
     virtual ~Mapper() = default;
 
     virtual void map(const Configuration& config) = 0;

--- a/include/Mapper.hpp
+++ b/include/Mapper.hpp
@@ -65,6 +65,14 @@ protected:
     virtual void placeRemainingArchitectureQubits();
     virtual void finalizeMappedCircuit();
 
+    virtual void countGates(const qc::QuantumComputation& circuit, MappingResults::CircuitInfo& info) {
+        countGates(circuit.cbegin(), circuit.cend(), info);
+    }
+    virtual void countGates(decltype(qcMapped.cbegin()) it, const decltype(qcMapped.cend())& end, MappingResults::CircuitInfo& info);
+
+    virtual void preMappingOptimizations(const Configuration& config);
+    virtual void postMappingOptimizations(const Configuration& config);
+
 public:
     Mapper(const qc::QuantumComputation& qc, Architecture& architecture);
     virtual ~Mapper() = default;

--- a/include/MappingResults.hpp
+++ b/include/MappingResults.hpp
@@ -64,7 +64,6 @@ struct MappingResults {
         circuit["gates"]              = input.gates;
         circuit["single_qubit_gates"] = input.singleQubitGates;
         circuit["cnots"]              = input.cnots;
-        circuit["layers"]             = input.layers;
 
         auto& mapped_circuit                 = resultJSON["mapped_circuit"];
         mapped_circuit["name"]               = output.name;
@@ -72,23 +71,24 @@ struct MappingResults {
         mapped_circuit["gates"]              = output.gates;
         mapped_circuit["single_qubit_gates"] = output.singleQubitGates;
         mapped_circuit["cnots"]              = output.cnots;
-        mapped_circuit["swaps"]              = output.swaps;
         if (!mappedCircuit.empty()) {
             mapped_circuit["qasm"] = mappedCircuit;
-        }
-        if (config.method == Method::Exact) {
-            mapped_circuit["direction_reverse"] = output.directionReverse;
-        } else if (config.method == Method::Heuristic) {
-            mapped_circuit["teleportations"] = output.teleportations;
         }
 
         resultJSON["config"] = config.json();
 
-        auto& stats               = resultJSON["statistics"];
-        stats["timeout"]          = timeout;
-        stats["mapping_time"]     = time;
-        stats["additional_gates"] = output.gates - input.gates;
-        stats["arch"]             = architecture;
+        auto& stats           = resultJSON["statistics"];
+        stats["timeout"]      = timeout;
+        stats["mapping_time"] = time;
+        stats["arch"]         = architecture;
+        stats["layers"]       = input.layers;
+        stats["swaps"]        = output.swaps;
+        if (config.method == Method::Exact) {
+            stats["direction_reverse"] = output.directionReverse;
+        } else if (config.method == Method::Heuristic) {
+            stats["teleportations"] = output.teleportations;
+        }
+        stats["additional_gates"] = static_cast<long>(output.gates) - input.gates;
 
         return resultJSON;
     }

--- a/include/configuration/Configuration.hpp
+++ b/include/configuration/Configuration.hpp
@@ -22,6 +22,9 @@ struct Configuration {
     // which method to use
     Method method = Method::Heuristic;
 
+    bool preMappingOptimizations  = true;
+    bool postMappingOptimizations = true;
+
     bool verbose = false;
 
     // map to particular subgraph of architecture (in exact mapper)
@@ -73,7 +76,9 @@ struct Configuration {
         if (!subgraph.empty()) {
             config["subgraph"] = subgraph;
         }
-        config["verbose"] = verbose;
+        config["pre_mapping_optimizations"]  = preMappingOptimizations;
+        config["post_mapping_optimizations"] = postMappingOptimizations;
+        config["verbose"]                    = verbose;
 
         if (method == Method::Heuristic) {
             auto& heuristic             = config["settings"];

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -184,6 +184,8 @@ PYBIND11_MODULE(pyqmap, m) {
             .def_readwrite("swap_limit", &Configuration::swapLimit)
             .def_readwrite("use_bdd", &Configuration::useBDD)
             .def_readwrite("subgraph", &Configuration::subgraph)
+            .def_readwrite("pre_mapping_optimizations", &Configuration::preMappingOptimizations)
+            .def_readwrite("post_mapping_optimizations", &Configuration::postMappingOptimizations)
             .def("json", &Configuration::json)
             .def("__repr__", &Configuration::toString);
 

--- a/mqt/qmap/compile.py
+++ b/mqt/qmap/compile.py
@@ -24,6 +24,8 @@ def compile(circ, arch: Union[str, Arch],
             include_WCNF: bool = False,
             use_subsets: bool = True,
             subgraph: Optional[Set[int]] = None,
+            pre_mapping_optimizations: bool = True,
+            post_mapping_optimizations: bool = True,
             verbose: bool = False
             ) -> MappingResults:
     """Interface to the MQT QMAP tool for mapping quantum circuits
@@ -57,6 +59,10 @@ def compile(circ, arch: Union[str, Arch],
     :param use_teleportation:  Use teleportation in addition to swaps
     :param teleportation_fake: Assign qubits as ancillary for teleportation in the initial placement but don't actually use them (used for comparisons)
     :param teleportation_seed: Fix a seed for the RNG in the initial ancilla placement (0 means the RNG will be seeded from /dev/urandom/ or similar)
+    :param pre_mapping_optimizations: Run pre-mapping optimizations (default: True)
+    :type pre_mapping_optimizations: bool
+    :param post_mapping_optimizations: Run post-mapping optimizations (default: True)
+    :type post_mapping_optimizations: bool
     :param verbose: Print more detailed information during the mapping process
     :type verbose: bool
     :return: Object containing all the results
@@ -84,6 +90,8 @@ def compile(circ, arch: Union[str, Arch],
     config.use_teleportation = use_teleportation
     config.teleportation_fake = teleportation_fake
     config.teleportation_seed = teleportation_seed
+    config.pre_mapping_optimizations = pre_mapping_optimizations
+    config.post_mapping_optimizations = post_mapping_optimizations
     config.verbose = verbose
 
     return map(circ, arch, config)

--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -51,9 +51,9 @@ void Mapper::createLayers() {
         bool  singleQubit = gate->getControls().empty();
         short control     = -1;
         if (!singleQubit) {
-            control = static_cast<short>((*gate->getControls().begin()).qubit);
+            control = static_cast<short>(qc.initialLayout.at((*gate->getControls().begin()).qubit));
         }
-        unsigned short target = gate->getTargets().at(0);
+        unsigned short target = qc.initialLayout.at(gate->getTargets().at(0));
         size_t         layer  = 0;
 
         switch (config.layering) {

--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -15,8 +15,8 @@ void Mapper::initResults() {
     qcMapped.addQubitRegister(architecture.getNqubits());
 }
 
-Mapper::Mapper(qc::QuantumComputation& quantumComputation, Architecture& arch):
-    qc(quantumComputation), architecture(arch) {
+Mapper::Mapper(const qc::QuantumComputation& quantumComputation, Architecture& arch):
+    qc(quantumComputation.clone()), architecture(arch) {
     qubits.fill(DEFAULT_POSITION);
     locations.fill(DEFAULT_POSITION);
     fidelities.fill(INITIAL_FIDELITY);

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -15,8 +15,10 @@ void HeuristicMapper::map(const Configuration& ms) {
         return;
     }
     const auto start = std::chrono::steady_clock::now();
-    qc.stripIdleQubits(true, false);
     initResults();
+
+    // perform pre-mapping optimizations
+    preMappingOptimizations(config);
 
     createLayers();
     if (config.verbose) {
@@ -50,15 +52,9 @@ void HeuristicMapper::map(const Configuration& ms) {
                 for (const auto& swap: swaps) {
                     if (swap.op == qc::SWAP) {
                         qcMapped.swap(swap.first, swap.second);
-                        if (architecture.bidirectional()) {
-                            results.output.gates += GATES_OF_BIDIRECTIONAL_SWAP;
-                        } else {
-                            results.output.gates += GATES_OF_UNIDIRECTIONAL_SWAP;
-                        }
                         results.output.swaps++;
                     } else if (swap.op == qc::Teleportation) {
                         qcMapped.emplace_back<qc::StandardOperation>(qcMapped.getNqubits(), qc::Targets{static_cast<dd::Qubit>(swap.first), static_cast<dd::Qubit>(swap.second), static_cast<dd::Qubit>(swap.middle_ancilla)}, qc::Teleportation);
-                        results.output.gates += COST_TELEPORTATION;
                         results.output.teleportations++;
                     }
                     gateidx++;
@@ -82,8 +78,6 @@ void HeuristicMapper::map(const Configuration& ms) {
                                                                  op->getParameter().at(1),
                                                                  op->getParameter().at(2));
                     gatesToAdjust.push_back(gateidx);
-                    results.output.gates++;
-                    results.output.singleQubitGates++;
                     gateidx++;
                 } else {
                     qcMapped.emplace_back<qc::StandardOperation>(qcMapped.getNqubits(),
@@ -92,8 +86,6 @@ void HeuristicMapper::map(const Configuration& ms) {
                                                                  op->getParameter().at(0),
                                                                  op->getParameter().at(1),
                                                                  op->getParameter().at(2));
-                    results.output.gates++;
-                    results.output.singleQubitGates++;
                     gateidx++;
                 }
             } else {
@@ -110,13 +102,9 @@ void HeuristicMapper::map(const Configuration& ms) {
                     qcMapped.h(reverse.first);
 
                     results.output.directionReverse++;
-                    results.output.cnots++;
-                    results.output.gates += 5;
                     gateidx += 5;
                 } else {
                     qcMapped.x(cnot.second, dd::Control{static_cast<dd::Qubit>(cnot.first)});
-                    results.output.cnots++;
-                    results.output.gates++;
                     gateidx++;
                 }
             }
@@ -176,6 +164,9 @@ void HeuristicMapper::map(const Configuration& ms) {
             ++count;
         }
     }
+
+    postMappingOptimizations(config);
+    countGates(qcMapped, results.output);
     finalizeMappedCircuit();
 
     const auto                    end  = std::chrono::steady_clock::now();

--- a/test/test_exact.cpp
+++ b/test/test_exact.cpp
@@ -371,6 +371,7 @@ TEST_F(ExactTest, CircuitWithOnlySingleQubitGates) {
     qc.clear();
     qc.x(0);
     qc.x(1);
+    IBM_QX4_mapper = std::make_unique<ExactMapper>(qc, IBM_QX4);
     IBM_QX4_mapper->map(settings);
     IBM_QX4_mapper->dumpResult(std::cout, qc::OpenQASM);
     SUCCEED() << "Mapping successful";

--- a/test/test_exact.cpp
+++ b/test/test_exact.cpp
@@ -14,23 +14,35 @@ protected:
     std::string test_architecture_dir = "./architectures/";
     std::string test_calibration_dir  = "./calibration/";
 
-    qc::QuantumComputation qc{};
-    Configuration          settings{};
-    Architecture           IBMQ_Yorktown{};
-    Architecture           IBMQ_London{};
-    Architecture           IBM_QX4{};
-    ExactMapper            IBMQ_Yorktown_mapper{qc, IBMQ_Yorktown};
-    ExactMapper            IBMQ_London_mapper{qc, IBMQ_London};
-    ExactMapper            IBM_QX4_mapper{qc, IBM_QX4};
+    qc::QuantumComputation       qc{};
+    Configuration                settings{};
+    Architecture                 IBMQ_Yorktown{};
+    Architecture                 IBMQ_London{};
+    Architecture                 IBM_QX4{};
+    std::unique_ptr<ExactMapper> IBMQ_Yorktown_mapper;
+    std::unique_ptr<ExactMapper> IBMQ_London_mapper;
+    std::unique_ptr<ExactMapper> IBM_QX4_mapper;
 
     void SetUp() override {
+        using namespace dd::literals;
+
         if (::testing::UnitTest::GetInstance()->current_test_info()->value_param()) {
             qc.import(test_example_dir + GetParam() + ".qasm");
+        } else {
+            qc.addQubitRegister(3U);
+            qc.x(0, 1_pc);
+            qc.x(1, 2_pc);
+            qc.x(2, 0_pc);
         }
         IBMQ_Yorktown.loadCouplingMap(AvailableArchitecture::IBMQ_Yorktown);
         IBMQ_London.loadCouplingMap(test_architecture_dir + "ibmq_london.arch");
         IBMQ_London.loadCalibrationData(test_calibration_dir + "ibmq_london.csv");
         IBM_QX4.loadCouplingMap(AvailableArchitecture::IBM_QX4);
+
+        IBMQ_Yorktown_mapper = std::make_unique<ExactMapper>(qc, IBMQ_Yorktown);
+        IBMQ_London_mapper   = std::make_unique<ExactMapper>(qc, IBMQ_London);
+        IBM_QX4_mapper       = std::make_unique<ExactMapper>(qc, IBM_QX4);
+
         settings.verbose = true;
         settings.method  = Method::Exact;
     }
@@ -52,173 +64,173 @@ INSTANTIATE_TEST_SUITE_P(Exact, ExactTest,
 
 TEST_P(ExactTest, IndividualGates) {
     settings.layering = Layering::IndividualGates;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_individual.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_individual.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
 
-    IBMQ_London_mapper.map(settings);
-    IBMQ_London_mapper.dumpResult(GetParam() + "_exact_london_individual.qasm");
-    IBMQ_London_mapper.printResult(std::cout);
+    IBMQ_London_mapper->map(settings);
+    IBMQ_London_mapper->dumpResult(GetParam() + "_exact_london_individual.qasm");
+    IBMQ_London_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
 TEST_P(ExactTest, DisjointQubits) {
     settings.layering = Layering::DisjointQubits;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_disjoint.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_disjoint.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
 
-    IBMQ_London_mapper.map(settings);
-    IBMQ_London_mapper.dumpResult(GetParam() + "_exact_london_disjoint.qasm");
-    IBMQ_London_mapper.printResult(std::cout);
+    IBMQ_London_mapper->map(settings);
+    IBMQ_London_mapper->dumpResult(GetParam() + "_exact_london_disjoint.qasm");
+    IBMQ_London_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
 TEST_P(ExactTest, OddGates) {
     settings.layering = Layering::OddGates;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_odd.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_odd.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
 TEST_P(ExactTest, QubitTriangle) {
     settings.layering = Layering::QubitTriangle;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_triangle.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_triangle.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
 TEST_P(ExactTest, CommanderEncodingfixed3) {
     settings.encoding          = Encoding::Commander;
     settings.commanderGrouping = CommanderGrouping::Fixed3;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_commander_fixed3.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_commander_fixed3.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, CommanderEncodingfixed2) {
     settings.encoding          = Encoding::Commander;
     settings.commanderGrouping = CommanderGrouping::Fixed2;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_commander_fixed2.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_commander_fixed2.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, CommanderEncodinghalves) {
     settings.encoding          = Encoding::Commander;
     settings.commanderGrouping = CommanderGrouping::Halves;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_commander_halves.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_commander_halves.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, CommanderEncodinglogarithm) {
     settings.encoding          = Encoding::Commander;
     settings.commanderGrouping = CommanderGrouping::Logarithm;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_commander_log.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_commander_log.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
 TEST_P(ExactTest, CommanderEncodingUnidirectionalfixed3) {
     settings.encoding          = Encoding::Commander;
     settings.commanderGrouping = CommanderGrouping::Fixed3;
-    IBM_QX4_mapper.map(settings);
-    IBM_QX4_mapper.dumpResult(GetParam() + "_exact_QX4_commander_fixed3.qasm");
-    IBM_QX4_mapper.printResult(std::cout);
+    IBM_QX4_mapper->map(settings);
+    IBM_QX4_mapper->dumpResult(GetParam() + "_exact_QX4_commander_fixed3.qasm");
+    IBM_QX4_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, CommanderEncodingUnidirectionalfixed2) {
     settings.encoding          = Encoding::Commander;
     settings.commanderGrouping = CommanderGrouping::Fixed2;
-    IBM_QX4_mapper.map(settings);
-    IBM_QX4_mapper.dumpResult(GetParam() + "_exact_QX4_commander_fixed2.qasm");
-    IBM_QX4_mapper.printResult(std::cout);
+    IBM_QX4_mapper->map(settings);
+    IBM_QX4_mapper->dumpResult(GetParam() + "_exact_QX4_commander_fixed2.qasm");
+    IBM_QX4_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, CommanderEncodingUnidirectionalhalves) {
     settings.encoding          = Encoding::Commander;
     settings.commanderGrouping = CommanderGrouping::Halves;
-    IBM_QX4_mapper.map(settings);
-    IBM_QX4_mapper.dumpResult(GetParam() + "_exact_QX4_commander_halves.qasm");
-    IBM_QX4_mapper.printResult(std::cout);
+    IBM_QX4_mapper->map(settings);
+    IBM_QX4_mapper->dumpResult(GetParam() + "_exact_QX4_commander_halves.qasm");
+    IBM_QX4_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, CommanderEncodingUnidirectionallogarithm) {
     settings.encoding          = Encoding::Commander;
     settings.commanderGrouping = CommanderGrouping::Logarithm;
-    IBM_QX4_mapper.map(settings);
-    IBM_QX4_mapper.dumpResult(GetParam() + "_exact_QX4_commander_log.qasm");
-    IBM_QX4_mapper.printResult(std::cout);
+    IBM_QX4_mapper->map(settings);
+    IBM_QX4_mapper->dumpResult(GetParam() + "_exact_QX4_commander_log.qasm");
+    IBM_QX4_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
 TEST_P(ExactTest, BimanderEncodingfixed3) {
     settings.encoding          = Encoding::Bimander;
     settings.commanderGrouping = CommanderGrouping::Fixed3;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_bimander.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_bimander.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, BimanderEncodingfixed2) {
     settings.encoding          = Encoding::Bimander;
     settings.commanderGrouping = CommanderGrouping::Fixed2;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_bimander.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_bimander.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, BimanderEncodinghalves) {
     settings.encoding          = Encoding::Bimander;
     settings.commanderGrouping = CommanderGrouping::Halves;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_bimander.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_bimander.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, BimanderEncodinglogaritm) {
     settings.encoding          = Encoding::Bimander;
     settings.commanderGrouping = CommanderGrouping::Logarithm;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_bimander.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_bimander.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
 TEST_P(ExactTest, BimanderEncodingUnidirectionalfixed3) {
     settings.encoding          = Encoding::Bimander;
     settings.commanderGrouping = CommanderGrouping::Fixed3;
-    IBM_QX4_mapper.map(settings);
-    IBM_QX4_mapper.dumpResult(GetParam() + "_exact_QX4_bimander.qasm");
-    IBM_QX4_mapper.printResult(std::cout);
+    IBM_QX4_mapper->map(settings);
+    IBM_QX4_mapper->dumpResult(GetParam() + "_exact_QX4_bimander.qasm");
+    IBM_QX4_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, BimanderEncodingUnidirectionalfixed2) {
     settings.encoding          = Encoding::Bimander;
     settings.commanderGrouping = CommanderGrouping::Fixed2;
-    IBM_QX4_mapper.map(settings);
-    IBM_QX4_mapper.dumpResult(GetParam() + "_exact_QX4_bimander.qasm");
-    IBM_QX4_mapper.printResult(std::cout);
+    IBM_QX4_mapper->map(settings);
+    IBM_QX4_mapper->dumpResult(GetParam() + "_exact_QX4_bimander.qasm");
+    IBM_QX4_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, BimanderEncodingUnidirectionalhalves) {
     settings.encoding          = Encoding::Bimander;
     settings.commanderGrouping = CommanderGrouping::Halves;
-    IBM_QX4_mapper.map(settings);
-    IBM_QX4_mapper.dumpResult(GetParam() + "_exact_QX4_bimander.qasm");
-    IBM_QX4_mapper.printResult(std::cout);
+    IBM_QX4_mapper->map(settings);
+    IBM_QX4_mapper->dumpResult(GetParam() + "_exact_QX4_bimander.qasm");
+    IBM_QX4_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, BimanderEncodingUnidirectionallogarithm) {
     settings.encoding          = Encoding::Bimander;
     settings.commanderGrouping = CommanderGrouping::Logarithm;
-    IBM_QX4_mapper.map(settings);
-    IBM_QX4_mapper.dumpResult(GetParam() + "_exact_QX4_bimander.qasm");
-    IBM_QX4_mapper.printResult(std::cout);
+    IBM_QX4_mapper->map(settings);
+    IBM_QX4_mapper->dumpResult(GetParam() + "_exact_QX4_bimander.qasm");
+    IBM_QX4_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
@@ -226,27 +238,27 @@ TEST_P(ExactTest, LimitsBidirectional) {
     settings.enableSwapLimits = true;
     settings.useSubsets       = false;
     settings.swapReduction    = SwapReduction::CouplingLimit;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_swapreduct.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_swapreduct.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, LimitsBidirectionalSubsetSwaps) {
     settings.enableSwapLimits = true;
     settings.useSubsets       = true;
     settings.swapReduction    = SwapReduction::CouplingLimit;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_swapreduct.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_swapreduct.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, LimitsBidirectionalCustomLimit) {
     settings.enableSwapLimits = true;
     settings.swapReduction    = SwapReduction::Custom;
     settings.swapLimit        = 10;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_swapreduct.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_swapreduct.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
@@ -254,45 +266,45 @@ TEST_P(ExactTest, LimitsUnidirectional) {
     settings.enableSwapLimits = true;
     settings.useSubsets       = false;
     settings.swapReduction    = SwapReduction::CouplingLimit;
-    IBM_QX4_mapper.map(settings);
-    IBM_QX4_mapper.dumpResult(GetParam() + "_exact_QX4_swapreduct.qasm");
-    IBM_QX4_mapper.printResult(std::cout);
+    IBM_QX4_mapper->map(settings);
+    IBM_QX4_mapper->dumpResult(GetParam() + "_exact_QX4_swapreduct.qasm");
+    IBM_QX4_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, LimitsUnidirectionalSubsetSwaps) {
     settings.enableSwapLimits = true;
     settings.useSubsets       = true;
     settings.swapReduction    = SwapReduction::CouplingLimit;
-    IBM_QX4_mapper.map(settings);
-    IBM_QX4_mapper.dumpResult(GetParam() + "_exact_QX4_swapreduct.qasm");
-    IBM_QX4_mapper.printResult(std::cout);
+    IBM_QX4_mapper->map(settings);
+    IBM_QX4_mapper->dumpResult(GetParam() + "_exact_QX4_swapreduct.qasm");
+    IBM_QX4_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, LimitsUnidirectionalCustomLimit) {
     settings.enableSwapLimits = true;
     settings.swapReduction    = SwapReduction::Custom;
     settings.swapLimit        = 10;
-    IBM_QX4_mapper.map(settings);
-    IBM_QX4_mapper.dumpResult(GetParam() + "_exact_QX4_swapreduct.qasm");
-    IBM_QX4_mapper.printResult(std::cout);
+    IBM_QX4_mapper->map(settings);
+    IBM_QX4_mapper->dumpResult(GetParam() + "_exact_QX4_swapreduct.qasm");
+    IBM_QX4_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, IncreasingCustomLimitUnidirectional) {
     settings.enableSwapLimits = true;
     settings.swapReduction    = SwapReduction::Increasing;
     settings.swapLimit        = 3;
-    IBM_QX4_mapper.map(settings);
-    IBM_QX4_mapper.dumpResult(GetParam() + "_exact_QX4_swapreduct_inccustom.qasm");
-    IBM_QX4_mapper.printResult(std::cout);
+    IBM_QX4_mapper->map(settings);
+    IBM_QX4_mapper->dumpResult(GetParam() + "_exact_QX4_swapreduct_inccustom.qasm");
+    IBM_QX4_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, IncreasingUnidirectional) {
     settings.enableSwapLimits = true;
     settings.swapReduction    = SwapReduction::Increasing;
     settings.swapLimit        = 0;
-    IBM_QX4_mapper.map(settings);
-    IBM_QX4_mapper.dumpResult(GetParam() + "_exact_QX4_swapreduct_inc.qasm");
-    IBM_QX4_mapper.printResult(std::cout);
+    IBM_QX4_mapper->map(settings);
+    IBM_QX4_mapper->dumpResult(GetParam() + "_exact_QX4_swapreduct_inc.qasm");
+    IBM_QX4_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
@@ -301,9 +313,9 @@ TEST_P(ExactTest, LimitsBidirectionalBDD) {
     settings.useSubsets       = false;
     settings.useBDD           = true;
     settings.swapReduction    = SwapReduction::CouplingLimit;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_swapreduct_bdd.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_swapreduct_bdd.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, LimitsBidirectionalSubsetSwapsBDD) {
@@ -311,18 +323,18 @@ TEST_P(ExactTest, LimitsBidirectionalSubsetSwapsBDD) {
     settings.useSubsets       = true;
     settings.useBDD           = true;
     settings.swapReduction    = SwapReduction::CouplingLimit;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_exact_yorktown_swapreduct_bdd.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_exact_yorktown_swapreduct_bdd.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
 TEST_P(ExactTest, NoSubsets) {
     settings.useSubsets       = false;
     settings.enableSwapLimits = false;
-    IBM_QX4_mapper.map(settings);
-    IBM_QX4_mapper.dumpResult(GetParam() + "_exact_QX4_nosubsets.qasm");
-    IBM_QX4_mapper.printResult(std::cout);
+    IBM_QX4_mapper->map(settings);
+    IBM_QX4_mapper->dumpResult(GetParam() + "_exact_QX4_nosubsets.qasm");
+    IBM_QX4_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
@@ -356,24 +368,17 @@ TEST_P(ExactTest, toStringMethods) {
 }
 
 TEST_F(ExactTest, CircuitWithOnlySingleQubitGates) {
-    qc.addQubitRegister(2U);
+    qc.clear();
     qc.x(0);
     qc.x(1);
-    IBM_QX4_mapper.map(settings);
-    IBM_QX4_mapper.dumpResult(std::cout, qc::OpenQASM);
+    IBM_QX4_mapper->map(settings);
+    IBM_QX4_mapper->dumpResult(std::cout, qc::OpenQASM);
     SUCCEED() << "Mapping successful";
 }
 
 TEST_F(ExactTest, MapToSubsetNotIncludingQ0) {
-    using namespace dd::literals;
-
     CouplingMap  cm{{0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 3}, {3, 2}, {1, 3}, {3, 1}};
     Architecture arch(4U, cm);
-
-    qc.addQubitRegister(3U);
-    qc.x(0, 1_pc);
-    qc.x(1, 2_pc);
-    qc.x(2, 0_pc);
 
     auto mapper         = ExactMapper(qc, arch);
     settings.useSubsets = false;
@@ -392,65 +397,37 @@ TEST_F(ExactTest, MapToSubsetNotIncludingQ0) {
 }
 
 TEST_F(ExactTest, WCNF) {
-    using namespace dd::literals;
-
-    qc.addQubitRegister(3U);
-    qc.x(0, 1_pc);
-    qc.x(1, 2_pc);
-    qc.x(2, 0_pc);
-
     settings.verbose     = false;
     settings.includeWCNF = true;
-    IBMQ_London_mapper.map(settings);
-    const auto& wcnf = IBMQ_London_mapper.getResults().wcnf;
+    IBMQ_London_mapper->map(settings);
+    const auto& wcnf = IBMQ_London_mapper->getResults().wcnf;
     std::cout << wcnf << std::endl;
     EXPECT_TRUE(!wcnf.empty());
 }
 
 TEST_F(ExactTest, MapToSubgraph) {
-    using namespace dd::literals;
-
-    qc.addQubitRegister(3U);
-    qc.x(0, 1_pc);
-    qc.x(1, 2_pc);
-    qc.x(2, 0_pc);
-
     const auto connectedSubset = std::set<unsigned short>{0U, 1U, 2U};
 
     settings.subgraph = connectedSubset;
-    IBMQ_London_mapper.map(settings);
-    const auto& results = IBMQ_London_mapper.getResults();
+    IBMQ_London_mapper->map(settings);
+    const auto& results = IBMQ_London_mapper->getResults();
     EXPECT_FALSE(results.timeout);
 }
 
 TEST_F(ExactTest, MapToSubgraphTooSmall) {
-    using namespace dd::literals;
-
-    qc.addQubitRegister(3U);
-    qc.x(0, 1_pc);
-    qc.x(1, 2_pc);
-    qc.x(2, 0_pc);
-
     const auto tooSmallSubset = std::set<unsigned short>{0U, 1U};
 
     settings.subgraph = tooSmallSubset;
-    IBMQ_London_mapper.map(settings);
-    const auto& results = IBMQ_London_mapper.getResults();
+    IBMQ_London_mapper->map(settings);
+    const auto& results = IBMQ_London_mapper->getResults();
     EXPECT_TRUE(results.timeout);
 }
 
 TEST_F(ExactTest, MapToSubgraphNotConnected) {
-    using namespace dd::literals;
-
-    qc.addQubitRegister(3U);
-    qc.x(0, 1_pc);
-    qc.x(1, 2_pc);
-    qc.x(2, 0_pc);
-
     const auto nonConnectedSubset = std::set<unsigned short>{0U, 2U, 3U};
 
     settings.subgraph = nonConnectedSubset;
-    IBMQ_London_mapper.map(settings);
-    const auto& results = IBMQ_London_mapper.getResults();
+    IBMQ_London_mapper->map(settings);
+    const auto& results = IBMQ_London_mapper->getResults();
     EXPECT_TRUE(results.timeout);
 }

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -138,7 +138,7 @@ protected:
     std::string test_example_dir      = "../../examples/";
     std::string test_architecture_dir = "../../extern/architectures/";
 
-    qc::QuantumComputation qc{};
+    qc::QuantumComputation           qc{};
     Architecture                     arch{};
     std::unique_ptr<HeuristicMapper> tokyo_mapper;
 
@@ -177,7 +177,7 @@ protected:
     std::string test_example_dir      = "../../examples/";
     std::string test_architecture_dir = "../../extern/architectures/";
 
-    qc::QuantumComputation qc{};
+    qc::QuantumComputation           qc{};
     Architecture                     arch{};
     std::unique_ptr<HeuristicMapper> tokyo_mapper;
 

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -14,17 +14,19 @@ protected:
     std::string test_architecture_dir = "./architectures/";
     std::string test_calibration_dir  = "./calibration/";
 
-    qc::QuantumComputation qc{};
-    Architecture           IBMQ_Yorktown{};
-    Architecture           IBMQ_London{};
-    HeuristicMapper        IBMQ_Yorktown_mapper{qc, IBMQ_Yorktown};
-    HeuristicMapper        IBMQ_London_mapper{qc, IBMQ_London};
+    qc::QuantumComputation           qc{};
+    Architecture                     IBMQ_Yorktown{};
+    Architecture                     IBMQ_London{};
+    std::unique_ptr<HeuristicMapper> IBMQ_Yorktown_mapper;
+    std::unique_ptr<HeuristicMapper> IBMQ_London_mapper;
 
     void SetUp() override {
         qc.import(test_example_dir + GetParam() + ".qasm");
         IBMQ_Yorktown.loadCouplingMap(AvailableArchitecture::IBMQ_Yorktown);
         IBMQ_London.loadCouplingMap(test_architecture_dir + "ibmq_london.arch");
         IBMQ_London.loadCalibrationData(test_calibration_dir + "ibmq_london.csv");
+        IBMQ_Yorktown_mapper = std::make_unique<HeuristicMapper>(qc, IBMQ_Yorktown);
+        IBMQ_London_mapper   = std::make_unique<HeuristicMapper>(qc, IBMQ_London);
     }
 };
 
@@ -59,37 +61,37 @@ INSTANTIATE_TEST_SUITE_P(Heuristic, HeuristicTest5Q,
 TEST_P(HeuristicTest5Q, Identity) {
     Configuration settings{};
     settings.initialLayout = InitialLayout::Identity;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_heuristic_qx4_identity.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_heuristic_qx4_identity.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
 
-    IBMQ_London_mapper.map(settings);
-    IBMQ_London_mapper.dumpResult(GetParam() + "_heuristic_london_identity.qasm");
-    IBMQ_London_mapper.printResult(std::cout);
+    IBMQ_London_mapper->map(settings);
+    IBMQ_London_mapper->dumpResult(GetParam() + "_heuristic_london_identity.qasm");
+    IBMQ_London_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
 TEST_P(HeuristicTest5Q, Static) {
     Configuration settings{};
     settings.initialLayout = InitialLayout::Static;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_heuristic_qx4_static.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
-    IBMQ_London_mapper.map(settings);
-    IBMQ_London_mapper.dumpResult(GetParam() + "_heuristic_london_static.qasm");
-    IBMQ_London_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_heuristic_qx4_static.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
+    IBMQ_London_mapper->map(settings);
+    IBMQ_London_mapper->dumpResult(GetParam() + "_heuristic_london_static.qasm");
+    IBMQ_London_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
 TEST_P(HeuristicTest5Q, Dynamic) {
     Configuration settings{};
     settings.initialLayout = InitialLayout::Dynamic;
-    IBMQ_Yorktown_mapper.map(settings);
-    IBMQ_Yorktown_mapper.dumpResult(GetParam() + "_heuristic_qx4_dynamic.qasm");
-    IBMQ_Yorktown_mapper.printResult(std::cout);
-    IBMQ_London_mapper.map(settings);
-    IBMQ_London_mapper.dumpResult(GetParam() + "_heuristic_london_dynamic.qasm");
-    IBMQ_London_mapper.printResult(std::cout);
+    IBMQ_Yorktown_mapper->map(settings);
+    IBMQ_Yorktown_mapper->dumpResult(GetParam() + "_heuristic_qx4_dynamic.qasm");
+    IBMQ_Yorktown_mapper->printResult(std::cout);
+    IBMQ_London_mapper->map(settings);
+    IBMQ_London_mapper->dumpResult(GetParam() + "_heuristic_london_dynamic.qasm");
+    IBMQ_London_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
@@ -98,13 +100,14 @@ protected:
     std::string test_example_dir      = "../../examples/";
     std::string test_architecture_dir = "../../extern/architectures/";
 
-    qc::QuantumComputation qc{};
-    Architecture           IBM_QX5{};
-    HeuristicMapper        IBM_QX5_mapper{qc, IBM_QX5};
+    qc::QuantumComputation           qc{};
+    Architecture                     IBM_QX5{};
+    std::unique_ptr<HeuristicMapper> IBM_QX5_mapper;
 
     void SetUp() override {
         qc.import(test_example_dir + GetParam() + ".qasm");
         IBM_QX5.loadCouplingMap(AvailableArchitecture::IBM_QX5);
+        IBM_QX5_mapper = std::make_unique<HeuristicMapper>(qc, IBM_QX5);
     }
 };
 
@@ -124,9 +127,9 @@ INSTANTIATE_TEST_SUITE_P(Heuristic, HeuristicTest16Q,
 TEST_P(HeuristicTest16Q, Dynamic) {
     Configuration settings{};
     settings.initialLayout = InitialLayout::Dynamic;
-    IBM_QX5_mapper.map(settings);
-    IBM_QX5_mapper.dumpResult(GetParam() + "_heuristic_qx5_dynamic.qasm");
-    IBM_QX5_mapper.printResult(std::cout);
+    IBM_QX5_mapper->map(settings);
+    IBM_QX5_mapper->dumpResult(GetParam() + "_heuristic_qx5_dynamic.qasm");
+    IBM_QX5_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
@@ -136,12 +139,13 @@ protected:
     std::string test_architecture_dir = "../../extern/architectures/";
 
     qc::QuantumComputation qc{};
-    Architecture           arch{};
-    HeuristicMapper        tokyo_mapper{qc, arch};
+    Architecture                     arch{};
+    std::unique_ptr<HeuristicMapper> tokyo_mapper;
 
     void SetUp() override {
         qc.import(test_example_dir + GetParam() + ".qasm");
         arch.loadCouplingMap(AvailableArchitecture::IBMQ_Tokyo);
+        tokyo_mapper = std::make_unique<HeuristicMapper>(qc, arch);
     }
 };
 
@@ -162,9 +166,9 @@ INSTANTIATE_TEST_SUITE_P(Heuristic, HeuristicTest20Q,
 TEST_P(HeuristicTest20Q, Dynamic) {
     Configuration settings{};
     settings.initialLayout = InitialLayout::Dynamic;
-    tokyo_mapper.map(settings);
-    tokyo_mapper.dumpResult(GetParam() + "_heuristic_tokyo_dynamic.qasm");
-    tokyo_mapper.printResult(std::cout);
+    tokyo_mapper->map(settings);
+    tokyo_mapper->dumpResult(GetParam() + "_heuristic_tokyo_dynamic.qasm");
+    tokyo_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }
 
@@ -174,12 +178,13 @@ protected:
     std::string test_architecture_dir = "../../extern/architectures/";
 
     qc::QuantumComputation qc{};
-    Architecture           arch{};
-    HeuristicMapper        tokyo_mapper{qc, arch};
+    Architecture                     arch{};
+    std::unique_ptr<HeuristicMapper> tokyo_mapper;
 
     void SetUp() override {
         qc.import(test_example_dir + std::get<1>(GetParam()) + ".qasm");
         arch.loadCouplingMap(AvailableArchitecture::IBMQ_Tokyo);
+        tokyo_mapper = std::make_unique<HeuristicMapper>(qc, arch);
     }
 };
 
@@ -199,8 +204,8 @@ TEST_P(HeuristicTest20QTeleport, Teleportation) {
     settings.initialLayout       = InitialLayout::Dynamic;
     settings.teleportationQubits = std::min((arch.getNqubits() - qc.getNqubits()) & ~1u, 8u);
     settings.teleportationSeed   = std::get<0>(GetParam());
-    tokyo_mapper.map(settings);
-    tokyo_mapper.dumpResult(std::get<1>(GetParam()) + "_heuristic_tokyo_teleport.qasm");
-    tokyo_mapper.printResult(std::cout);
+    tokyo_mapper->map(settings);
+    tokyo_mapper->dumpResult(std::get<1>(GetParam()) + "_heuristic_tokyo_teleport.qasm");
+    tokyo_mapper->printResult(std::cout);
     SUCCEED() << "Mapping successful";
 }


### PR DESCRIPTION
This PR adds the facilities to conduct pre- and post-mapping optimizations in QMAP.
At the moment, this merely contains a simple post-mapping optimization that tries to cancel adjacent CNOT gates.

Futhermore, this PR adopts the `clone()` functionality provided by the QFR library to clone the circuit upon importing it in the respective mapper in order to avoid side effects of the circuit optimizations conducted inside the mapper.

Finally, this PR slightly changes how gate counts for the resulting circuit are reported. Instead of separately listing the number of single-qubit gates, CNOTs, and SWAPs for the resulting circuit, the results now just list the number of resulting single-qubit and CNOT gates. The number of SWAPs, direction reverses, or teleportations directly resulting from the mapping is now listed in the `stats` part of the mapping result.