### PR TITLE
🚸 Small usability improvements

### DIFF
--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -126,13 +126,18 @@ void ExactMapper::map(const Configuration& settings) {
         unsigned int maxLimit = architecture.getCouplingLimit();
         unsigned int timeout  = 0;
         do {
-            timeout += settings.timeout * (static_cast<double>(limit * 0.5) / (maxLimit < upperLimit ? upperLimit : maxLimit));
-            if (timeout <= 10000)
-                timeout = 10000;
-            if (config.swapReduction != SwapReduction::Increasing)
+            if (config.swapReduction == SwapReduction::Increasing) {
+                timeout += settings.timeout * (static_cast<double>(limit * 0.5) / (maxLimit < upperLimit ? upperLimit : maxLimit));
+                if (timeout <= 10000U) {
+                    timeout = 10000U;
+                }
+                if (settings.verbose) {
+                    std::cout << "Timeout: " << timeout << "  Max-Timeout: " << settings.timeout << std::endl;
+                }
+            } else {
                 timeout = settings.timeout;
-            if (settings.verbose)
-                std::cout << "Timeout: " << timeout << "  Max-Timeout: " << settings.timeout << std::endl;
+            }
+
             // reset swaps
             for (auto& layer: swaps) {
                 layer.clear();

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -674,6 +674,13 @@ void ExactMapper::coreMappingRoutine(const std::set<unsigned short>& qubitChoice
     if (config.includeWCNF) {
         std::stringstream ss{};
         ss << opt;
+        try {
+            c.check_error();
+        } catch (const z3::exception& e) {
+            std::cerr << "Z3 reported an exception while trying to gather the WCNF formula: " << e.msg() << std::endl;
+            std::cerr << "Most likely, this is due to the usage of Z3's atMostOne and exactlyOne constraints." << std::endl;
+            std::cerr << "This can be circumvented by using QMAP's `commander` or `bimander` encoding." << std::endl;
+        }
         choiceResults.wcnf = ss.str();
     }
 

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -111,20 +111,26 @@ void ExactMapper::map(const Configuration& settings) {
     mappingSwaps.reserve(reducedLayerIndices.size());
     int runs = 1;
     for (auto& choice: allPossibleQubitChoices) {
-        std::size_t limit      = 0;
+        std::size_t limit      = 0U;
+        std::size_t maxLimit   = 0U;
         std::size_t upperLimit = config.swapLimit;
+        if (config.useSubsets) {
+            maxLimit = architecture.getCouplingLimit(choice) - 1U;
+        } else {
+            maxLimit = architecture.getCouplingLimit() - 1U;
+        }
         if (config.swapReduction == SwapReduction::CouplingLimit) {
-            if (config.useSubsets)
-                limit = architecture.getCouplingLimit(choice) - 1;
-            else
-                limit = architecture.getCouplingLimit() - 1;
+            limit = maxLimit;
         } else if (config.swapReduction == SwapReduction::Increasing) {
-            limit = 0;
+            limit = 0U;
         } else { //CustomLimit
             limit = upperLimit;
         }
-        unsigned int maxLimit = architecture.getCouplingLimit();
-        unsigned int timeout  = 0;
+        if (config.verbose && config.swapReduction != SwapReduction::None) {
+            std::cout << "SWAP limit: " << limit << std::endl;
+        }
+
+        unsigned int timeout = 0U;
         do {
             if (config.swapReduction == SwapReduction::Increasing) {
                 timeout += settings.timeout * (static_cast<double>(limit * 0.5) / (maxLimit < upperLimit ? upperLimit : maxLimit));

--- a/test/test_exact.cpp
+++ b/test/test_exact.cpp
@@ -401,8 +401,8 @@ TEST_F(ExactTest, WCNF) {
     settings.verbose     = false;
     settings.includeWCNF = true;
     IBMQ_London_mapper->map(settings);
+    IBMQ_London_mapper->printResult(std::cout);
     const auto& wcnf = IBMQ_London_mapper->getResults().wcnf;
-    std::cout << wcnf << std::endl;
     EXPECT_TRUE(!wcnf.empty());
 }
 

--- a/test/test_exact.cpp
+++ b/test/test_exact.cpp
@@ -406,6 +406,30 @@ TEST_F(ExactTest, WCNF) {
     EXPECT_TRUE(!wcnf.empty());
 }
 
+TEST_F(ExactTest, WCNF_not_available) {
+    using namespace dd::literals;
+
+    settings.verbose     = false;
+    settings.includeWCNF = true;
+
+    auto circ = qc::QuantumComputation(5U);
+    circ.h(0);
+    circ.x(1, 0_pc);
+    circ.x(2, 0_pc);
+    circ.x(3, 0_pc);
+    circ.x(4, 0_pc);
+
+    auto mapper = ExactMapper(circ, IBMQ_London);
+
+    mapper.map(settings);
+    EXPECT_TRUE(mapper.getResults().wcnf.empty());
+
+    auto mapper2      = ExactMapper(circ, IBMQ_London);
+    settings.encoding = Encoding::Commander;
+    mapper2.map(settings);
+    EXPECT_FALSE(mapper2.getResults().wcnf.empty());
+}
+
 TEST_F(ExactTest, MapToSubgraph) {
     const auto connectedSubset = std::set<unsigned short>{0U, 1U, 2U};
 


### PR DESCRIPTION
This PR slightly improves the `verbose` output in the exact mapper to make it more useful.
It allows provides a hint to the user, when a WCNF formula could not be obtained by Z3 and how this might be fixed.
Last but not least, it removes a redundant calculation of the architecture coupling limit by slightly refactoring the code.