### PR TITLE
Encoding fixes

### DIFF
--- a/src/Encodings.cpp
+++ b/src/Encodings.cpp
@@ -106,7 +106,7 @@ std::vector<NestedVar> groupVars(const std::vector<z3::expr>& vars, std::size_t 
     for (unsigned long i = 0; i < vars.size(); i++) {
         vVars.emplace_back(NestedVar{i});
     }
-    if (vVars.size() <= 6)
+    if (vVars.size() <= 6 || maxSize <= 1)
         return vVars;
     return groupVarsAux(vVars, maxSize);
 }
@@ -123,6 +123,9 @@ std::vector<NestedVar> groupVarsAux(const std::vector<NestedVar>& vars, std::siz
         std::advance(from, static_cast<long>(i * numVars / numGr));
         auto to = from;
         std::advance(to, static_cast<long>(numVars / numGr));
+        if (i == numGr - 1) {
+            to = vars.end();
+        }
         ret.emplace_back(std::numeric_limits<unsigned long>::max(), std::vector<NestedVar>(from, to));
     }
     return groupVarsAux(ret, maxSize);

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -465,7 +465,7 @@ void ExactMapper::coreMappingRoutine(const std::set<unsigned short>& qubitChoice
     } else if (config.encoding == Encoding::Commander) {
         for (unsigned long k = 0; k < reducedLayerIndices.size(); ++k) {
             for (unsigned long i = 0; i < qubitChoice.size(); ++i) {
-                std::vector<expr> varIDs;
+                std::vector<expr> varIDs{};
                 for (unsigned short j = 0; j < qc.getNqubits(); ++j) {
                     varIDs.push_back(x[k][i][j]);
                 }
@@ -481,7 +481,7 @@ void ExactMapper::coreMappingRoutine(const std::set<unsigned short>& qubitChoice
             }
 
             for (unsigned short j = 0; j < qc.getNqubits(); ++j) {
-                std::vector<expr> varIDs;
+                std::vector<expr> varIDs{};
                 for (unsigned long i = 0; i < qubitChoice.size(); ++i) {
                     varIDs.push_back(x[k][i][j]);
                 }
@@ -500,8 +500,8 @@ void ExactMapper::coreMappingRoutine(const std::set<unsigned short>& qubitChoice
     } else if (config.encoding == Encoding::Bimander) {
         for (unsigned long k = 0; k < reducedLayerIndices.size(); ++k) {
             for (unsigned long i = 0; i < qubitChoice.size(); ++i) {
-                std::vector<expr>          vars;
-                std::vector<unsigned long> varIDs;
+                std::vector<expr>          vars{};
+                std::vector<unsigned long> varIDs{};
                 for (unsigned short j = 0; j < qc.getNqubits(); ++j) {
                     vars.emplace_back(x[k][i][j]);
                     varIDs.emplace_back(j);
@@ -510,7 +510,7 @@ void ExactMapper::coreMappingRoutine(const std::set<unsigned short>& qubitChoice
             }
 
             for (unsigned short j = 0; j < qc.getNqubits(); ++j) { //There is no exactly one Bimander
-                std::vector<expr> varIDs;
+                std::vector<expr> varIDs{};
                 for (unsigned long i = 0; i < qubitChoice.size(); ++i) {
                     varIDs.push_back(x[k][i][j]);
                 }

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -465,7 +465,7 @@ void ExactMapper::coreMappingRoutine(const std::set<unsigned short>& qubitChoice
     } else if (config.encoding == Encoding::Commander) {
         for (unsigned long k = 0; k < reducedLayerIndices.size(); ++k) {
             for (unsigned long i = 0; i < qubitChoice.size(); ++i) {
-                std::vector<expr> varIDs{};
+                std::vector<expr> varIDs;
                 for (unsigned short j = 0; j < qc.getNqubits(); ++j) {
                     varIDs.push_back(x[k][i][j]);
                 }
@@ -481,7 +481,7 @@ void ExactMapper::coreMappingRoutine(const std::set<unsigned short>& qubitChoice
             }
 
             for (unsigned short j = 0; j < qc.getNqubits(); ++j) {
-                std::vector<expr> varIDs{};
+                std::vector<expr> varIDs;
                 for (unsigned long i = 0; i < qubitChoice.size(); ++i) {
                     varIDs.push_back(x[k][i][j]);
                 }
@@ -500,8 +500,8 @@ void ExactMapper::coreMappingRoutine(const std::set<unsigned short>& qubitChoice
     } else if (config.encoding == Encoding::Bimander) {
         for (unsigned long k = 0; k < reducedLayerIndices.size(); ++k) {
             for (unsigned long i = 0; i < qubitChoice.size(); ++i) {
-                std::vector<expr>          vars{};
-                std::vector<unsigned long> varIDs{};
+                std::vector<expr>          vars;
+                std::vector<unsigned long> varIDs;
                 for (unsigned short j = 0; j < qc.getNqubits(); ++j) {
                     vars.emplace_back(x[k][i][j]);
                     varIDs.emplace_back(j);
@@ -510,7 +510,7 @@ void ExactMapper::coreMappingRoutine(const std::set<unsigned short>& qubitChoice
             }
 
             for (unsigned short j = 0; j < qc.getNqubits(); ++j) { //There is no exactly one Bimander
-                std::vector<expr> varIDs{};
+                std::vector<expr> varIDs;
                 for (unsigned long i = 0; i < qubitChoice.size(); ++i) {
                     varIDs.push_back(x[k][i][j]);
                 }


### PR DESCRIPTION
Logarithm sometimes crashing when max Group size is 1 and var count > 6
Last Group in Commander Grouping not including all elements if the Variable Count is not divisible by Group Size
