### PR TITLE
🔧 Small Infrastructure Update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,6 @@ jobs:
 
       - name: Build
         run:  |
-          cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_heuristic
-          cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_exact
           cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_heuristic_test
           cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_exact_test
 
@@ -98,8 +96,6 @@ jobs:
 
       - name: Build
         run:  |
-              cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_heuristic
-              cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_exact
               cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_heuristic_test
               cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_exact_test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ defaults:
 env:
   BUILD_TYPE: Release
   CMAKE_BUILD_PARALLEL_LEVEL: 2
-  Z3_GIT_TAG: z3-4.8.16
+  Z3_GIT_TAG: z3-4.8.17
 
 jobs:
   codestyle:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,8 @@ on:
   workflow_dispatch:
 
 env:
-  Z3_GIT_TAG: z3-4.8.16
-  Z3_HASH:    a6274d2eea099f27c19bfbd736f4909ee9a373124ef0c017954fd38d56f4061c
+  Z3_GIT_TAG: z3-4.8.17
+  Z3_HASH:    2f59c37465aecdfbcc50a5ba0fe627535c0ff4cffb9080bfbddc0a2af0f97b53
 
 jobs:
   build_manylinux_wheels:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           submodules: recursive
       - name: Build wheels
-        uses: pypa/cibuildwheel@2.7
+        uses: pypa/cibuildwheel@2.7.0
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
@@ -39,7 +39,7 @@ jobs:
       - name: Install Z3
         run:  brew install z3
       - name: Build wheels
-        uses: pypa/cibuildwheel@2.7
+        uses: pypa/cibuildwheel@2.7.0
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
@@ -57,7 +57,7 @@ jobs:
              curl -L -H "Authorization: Bearer QQ==" -o ${{ env.Z3_GIT_TAG }}.big_sur.bottle.tar.gz https://ghcr.io/v2/homebrew/core/z3/blobs/sha256:${{ env.Z3_HASH }}
              brew install -f ${{ env.Z3_GIT_TAG }}.big_sur.bottle.tar.gz
       - name: Build wheels
-        uses: pypa/cibuildwheel@2.7
+        uses: pypa/cibuildwheel@2.7.0
         env:
           CIBW_ARCHS_MACOS: arm64
       - uses: actions/upload-artifact@v3
@@ -91,7 +91,7 @@ jobs:
         working-directory: ${{github.workspace}}/z3/build
         run: cmake --build . --config Release --target INSTALL;
       - name: Build wheels
-        uses: pypa/cibuildwheel@2.7
+        uses: pypa/cibuildwheel@2.7.0
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           submodules: recursive
       - name: Build wheels
-        uses: pypa/cibuildwheel@2.6.1
+        uses: pypa/cibuildwheel@2.7
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
@@ -39,7 +39,7 @@ jobs:
       - name: Install Z3
         run:  brew install z3
       - name: Build wheels
-        uses: pypa/cibuildwheel@2.6.1
+        uses: pypa/cibuildwheel@2.7
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
@@ -57,7 +57,7 @@ jobs:
              curl -L -H "Authorization: Bearer QQ==" -o ${{ env.Z3_GIT_TAG }}.big_sur.bottle.tar.gz https://ghcr.io/v2/homebrew/core/z3/blobs/sha256:${{ env.Z3_HASH }}
              brew install -f ${{ env.Z3_GIT_TAG }}.big_sur.bottle.tar.gz
       - name: Build wheels
-        uses: pypa/cibuildwheel@2.6.1
+        uses: pypa/cibuildwheel@2.7
         env:
           CIBW_ARCHS_MACOS: arm64
       - uses: actions/upload-artifact@v3
@@ -91,7 +91,7 @@ jobs:
         working-directory: ${{github.workspace}}/z3/build
         run: cmake --build . --config Release --target INSTALL;
       - name: Build wheels
-        uses: pypa/cibuildwheel@2.6.1
+        uses: pypa/cibuildwheel@2.7
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/apps/exact_app.cpp
+++ b/apps/exact_app.cpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #include "exact/ExactMapper.hpp"

--- a/apps/heuristic_app.cpp
+++ b/apps/heuristic_app.cpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #include "heuristic/HeuristicMapper.hpp"

--- a/include/Architecture.hpp
+++ b/include/Architecture.hpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #ifndef QMAP_ARCHITECTURE_HPP

--- a/include/Encodings.hpp
+++ b/include/Encodings.hpp
@@ -1,6 +1,6 @@
 /*
 * This file is part of the MQT QMAP library which is released under the MIT license.
-* See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+* See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
 */
 
 #ifndef Encodings_hpp

--- a/include/Mapper.hpp
+++ b/include/Mapper.hpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #ifndef QMAP_MAPPER_HPP

--- a/include/MappingResults.hpp
+++ b/include/MappingResults.hpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #include "configuration/Configuration.hpp"

--- a/include/configuration/AvailableArchitecture.hpp
+++ b/include/configuration/AvailableArchitecture.hpp
@@ -1,6 +1,6 @@
 /*
 * This file is part of the MQT QMAP library which is released under the MIT license.
-* See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+* See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
 */
 
 #ifndef QMAP_AVAILABLEARCHITECTURE_HPP

--- a/include/configuration/CommanderGrouping.hpp
+++ b/include/configuration/CommanderGrouping.hpp
@@ -1,6 +1,6 @@
 /*
 * This file is part of the MQT QMAP library which is released under the MIT license.
-* See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+* See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
 */
 
 #ifndef QMAP_COMMANDERGROUPING_HPP

--- a/include/configuration/Configuration.hpp
+++ b/include/configuration/Configuration.hpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #ifndef QMAP_CONFIGURATION_HPP

--- a/include/configuration/Encoding.hpp
+++ b/include/configuration/Encoding.hpp
@@ -1,6 +1,6 @@
 /*
 * This file is part of the MQT QMAP library which is released under the MIT license.
-* See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+* See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
 */
 
 #ifndef QMAP_ENCODING_HPP

--- a/include/configuration/InitialLayout.hpp
+++ b/include/configuration/InitialLayout.hpp
@@ -1,6 +1,6 @@
 /*
 * This file is part of the MQT QMAP library which is released under the MIT license.
-* See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+* See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
 */
 
 #ifndef QMAP_INITIALLAYOUT_HPP

--- a/include/configuration/Method.hpp
+++ b/include/configuration/Method.hpp
@@ -1,6 +1,6 @@
 /*
 * This file is part of the MQT QMAP library which is released under the MIT license.
-* See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+* See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
 */
 
 #ifndef QMAP_METHOD_HPP

--- a/include/configuration/SwapReduction.hpp
+++ b/include/configuration/SwapReduction.hpp
@@ -1,6 +1,6 @@
 /*
 * This file is part of the MQT QMAP library which is released under the MIT license.
-* See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+* See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
 */
 
 #ifndef QMAP_SWAPREDUCTION_HPP

--- a/include/exact/ExactMapper.hpp
+++ b/include/exact/ExactMapper.hpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #ifndef EXACT_MAPPER_hpp

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #include "Mapper.hpp"

--- a/include/heuristic/unique_priority_queue.hpp
+++ b/include/heuristic/unique_priority_queue.hpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #include <cassert>

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #ifndef QMAP_UTILS_HPP

--- a/mqt/qmap/CMakeLists.txt
+++ b/mqt/qmap/CMakeLists.txt
@@ -5,11 +5,3 @@ if (Z3_FOUND)
 	target_link_libraries(py${PROJECT_NAME} PUBLIC ${PROJECT_NAME}_exact_lib)
 	target_compile_definitions(py${PROJECT_NAME} PRIVATE VERSION_INFO=${QMAP_VERSION_INFO})
 endif()
-
-# LTO is disabled since a bug in manylinux2014 prevents the project from linking with it
-if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Linux")
-	set_target_properties(${PROJECT_NAME}_exact_lib PROPERTIES INTERPROCEDURAL_OPTIMIZATION FALSE)
-	set_target_properties(${PROJECT_NAME}_heuristic_lib PROPERTIES INTERPROCEDURAL_OPTIMIZATION FALSE)
-	set_target_properties(qfr PROPERTIES INTERPROCEDURAL_OPTIMIZATION FALSE)
-	set_target_properties(DDPackage PROPERTIES INTERPROCEDURAL_OPTIMIZATION FALSE)
-endif ()

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -1,6 +1,6 @@
 /*
 * This file is part of MQT QMAP library which is released under the MIT license.
-* See file README.md or go to http://iic.jku.at/eda/research/quantum/ for more information.
+* See file README.md or go to https://www.cda.cit.tum.de/research/quantum/ for more information.
 */
 
 #ifdef Z3_FOUND

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ test-skip = "*-macosx_arm64 *-musllinux* *aarch64"
 test-command = "python -c \"from mqt import qmap\""
 environment = { DEPLOY = "ON" }
 build-verbosity = 3
+manylinux-x86_64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.linux]
 before-all = "/opt/python/cp39-cp39/bin/python -m pip install --upgrade pip && /opt/python/cp39-cp39/bin/python -m pip install z3-solver"

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #include "Architecture.hpp"

--- a/src/Encodings.cpp
+++ b/src/Encodings.cpp
@@ -1,6 +1,6 @@
 /*
 * This file is part of the MQT QMAP library which is released under the MIT license.
-* See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+* See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
 */
 
 #include "Encodings.hpp"

--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #include "Mapper.hpp"

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #include "exact/ExactMapper.hpp"

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #include "heuristic/HeuristicMapper.hpp"

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #include <utils.hpp>

--- a/test/test_exact.cpp
+++ b/test/test_exact.cpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #include "exact/ExactMapper.hpp"

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #include "Architecture.hpp"

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -1,6 +1,6 @@
 /*
  * This file is part of the MQT QMAP library which is released under the MIT license.
- * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
 #include "heuristic/HeuristicMapper.hpp"


### PR DESCRIPTION
This PR updates some of the internal infrastructure

- updates the Z3 version used when creating the Python packages to 4.8.17
- updates the manylinux images used for building wheels to `manylinux_2_28` as this should allow to drop the LTO limitation currently in place for manylinux2014
- fixes the URLs in the file headers