### PR TITLE
✨ Native Support for Qiskit Backends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Build
         run:  |
+          cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_heuristic
+          cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_exact
           cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_heuristic_test
           cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_exact_test
 
@@ -96,6 +98,8 @@ jobs:
 
       - name: Build
         run:  |
+              cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_heuristic
+              cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_exact
               cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_heuristic_test
               cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qmap_exact_test
 

--- a/README.md
+++ b/README.md
@@ -37,20 +37,7 @@ It builds upon [our quantum functionality representation (QFR)](https://github.c
 * `TFC` (e.g. from [Reversible Logic Synthesis Benchmarks Page](http://webhome.cs.uvic.ca/~dmaslov/mach-read.html))
 * `QC` (e.g. from [Feynman](https://github.com/meamy/feynman))
 
-to any given architecture, e.g., the 5-qubit, T-shaped IBMQ London architecture, which is specified by the coupling map
-
-```
-5
-0 1
-1 0
-1 2
-2 1
-1 3
-3 1
-3 4
-4 3
-```
-with the following available methods:
+to any given architecture with the following available methods:
 
 - **Heuristic Mapper**:  Heuristic solution based on A* search. For details see [[1]](https://www.cda.cit.tum.de/files/eda/2018_tcad_efficient_mapping_of_quantum_circuits_to_ibm_qx_architectures.pdf)
   and [[3]](https://www.cda.cit.tum.de/files/eda/2021_aspdac_exploiting_teleportation_in_quantum_circuit_mappping.pdf).
@@ -78,14 +65,18 @@ MQT QMAP is developed as a C++ library with an easy to use Python interface.
   This enables platform specific compiler optimizations that cannot be enabled on portable wheels.
 - Once installed, start using it in Python:
     ```python
-    from mqt.qmap import *
-    results = compile(circ, arch)
+    from mqt import qmap
+    results = qmap.compile(circ, arch)
     ```
 
 where `circ` is either a Qiskit `QuantumCircuit` object or the path to an input file (in any of the formats listed above)
-and `arch` is either one of the pre-defined architectures (see below) or the path to a file containing the number of qubits and a line-by-line enumeration of the qubit connections.
+and `arch` is either
 
-Architectures that are available per default (either as strings or under `qmap.Arch.<...>`) include (corresponding files are available in `extern/architectures/`):
+- a Qiskit `Backend` instance such as those defined under `qiskit.test.mock` **(recommended)**,
+- one of the pre-defined architectures (see below), or
+- the path to a file containing the number of qubits and a line-by-line enumeration of the qubit connections.
+
+Architectures that are available per default (either as strings or under `qmap.Arch.<...>`) include:
 
 - `IBM_QX4` (5 qubit, directed bow tie layout)
 - `IBM_QX5` (16 qubit, directed ladder layout)
@@ -192,7 +183,7 @@ Internally the MQT QMAP library works in the following way
 - (Optional) Import calibration file into `arch` object
     ```c++
     std::string cal = "<PATH_TO_CAL_FILE>";
-    arch.loadCalibrationData(cal);
+    arch.loadProperties(cal);
     ```
 - Depending on `Method`, instantiate a `HeuristicMapper` or `ExactMapper` object with the circuit and the architecture
     ```c++

--- a/apps/exact_app.cpp
+++ b/apps/exact_app.cpp
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
     if (vm.count("calibration")) {
         const std::string cal = vm["calibration"].as<std::string>();
         try {
-            arch.loadCalibrationData(cal);
+            arch.loadProperties(cal);
         } catch (std::exception const& e) {
             std::stringstream ss{};
             ss << "Could not import calibration data: " << e.what();

--- a/apps/heuristic_app.cpp
+++ b/apps/heuristic_app.cpp
@@ -68,7 +68,7 @@ int main(int argc, char** argv) {
     if (vm.count("calibration")) {
         const std::string cal = vm["calibration"].as<std::string>();
         try {
-            arch.loadCalibrationData(cal);
+            arch.loadProperties(cal);
         } catch (std::exception const& e) {
             std::stringstream ss{};
             ss << "Could not import calibration data: " << e.what();

--- a/include/Architecture.hpp
+++ b/include/Architecture.hpp
@@ -267,8 +267,8 @@ public:
     }
 
     void reset() {
-        name = "";
-        nqubits          = 0;
+        name    = "";
+        nqubits = 0;
         couplingMap.clear();
         distanceTable.clear();
         isBidirectional = true;

--- a/include/MappingResults.hpp
+++ b/include/MappingResults.hpp
@@ -4,6 +4,7 @@
  */
 
 #include "configuration/Configuration.hpp"
+#include "Architecture.hpp"
 
 #include <iostream>
 #include <sstream>
@@ -30,7 +31,7 @@ struct MappingResults {
 
     CircuitInfo input{};
 
-    std::string   architecture{};
+    Architecture* architecture{};
     Configuration config{};
 
     double time    = 0.0;
@@ -80,7 +81,7 @@ struct MappingResults {
         auto& stats           = resultJSON["statistics"];
         stats["timeout"]      = timeout;
         stats["mapping_time"] = time;
-        stats["arch"]         = architecture;
+        stats["arch"]         = architecture? architecture->getName() : "";
         stats["layers"]       = input.layers;
         stats["swaps"]        = output.swaps;
         if (config.method == Method::Exact) {
@@ -103,7 +104,7 @@ struct MappingResults {
            << input.gates << ";"
            << input.singleQubitGates << ";"
            << input.cnots << ";"
-           << architecture << ";"
+           << (architecture? architecture->getName(): "") << ";"
            << output.name << ";"
            << output.qubits << ";"
            << output.gates << ";"

--- a/include/MappingResults.hpp
+++ b/include/MappingResults.hpp
@@ -3,8 +3,8 @@
  * See file README.md or go to https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
-#include "configuration/Configuration.hpp"
 #include "Architecture.hpp"
+#include "configuration/Configuration.hpp"
 
 #include <iostream>
 #include <sstream>
@@ -81,7 +81,7 @@ struct MappingResults {
         auto& stats           = resultJSON["statistics"];
         stats["timeout"]      = timeout;
         stats["mapping_time"] = time;
-        stats["arch"]         = architecture? architecture->getName() : "";
+        stats["arch"]         = architecture ? architecture->getName() : "";
         stats["layers"]       = input.layers;
         stats["swaps"]        = output.swaps;
         if (config.method == Method::Exact) {
@@ -104,7 +104,7 @@ struct MappingResults {
            << input.gates << ";"
            << input.singleQubitGates << ";"
            << input.cnots << ";"
-           << (architecture? architecture->getName(): "") << ";"
+           << (architecture ? architecture->getName() : "") << ";"
            << output.name << ";"
            << output.qubits << ";"
            << output.gates << ";"

--- a/include/MappingResults.hpp
+++ b/include/MappingResults.hpp
@@ -31,7 +31,7 @@ struct MappingResults {
 
     CircuitInfo input{};
 
-    Architecture* architecture{};
+    std::string   architecture{};
     Configuration config{};
 
     double time    = 0.0;
@@ -81,7 +81,7 @@ struct MappingResults {
         auto& stats           = resultJSON["statistics"];
         stats["timeout"]      = timeout;
         stats["mapping_time"] = time;
-        stats["arch"]         = architecture ? architecture->getName() : "";
+        stats["arch"]         = architecture;
         stats["layers"]       = input.layers;
         stats["swaps"]        = output.swaps;
         if (config.method == Method::Exact) {
@@ -104,7 +104,7 @@ struct MappingResults {
            << input.gates << ";"
            << input.singleQubitGates << ";"
            << input.cnots << ";"
-           << (architecture ? architecture->getName() : "") << ";"
+           << architecture << ";"
            << output.name << ";"
            << output.qubits << ";"
            << output.gates << ";"

--- a/include/configuration/Configuration.hpp
+++ b/include/configuration/Configuration.hpp
@@ -17,8 +17,6 @@
 struct Configuration {
     Configuration() = default;
 
-    std::string calibration{};
-
     // which method to use
     Method method = Method::Heuristic;
 
@@ -71,7 +69,6 @@ struct Configuration {
     [[nodiscard]] nlohmann::json json() const {
         nlohmann::json config{};
         config["method"]            = ::toString(method);
-        config["calibration"]       = calibration;
         config["layering_strategy"] = ::toString(layering);
         if (!subgraph.empty()) {
             config["subgraph"] = subgraph;

--- a/mqt/qmap/__init__.py
+++ b/mqt/qmap/__init__.py
@@ -4,4 +4,6 @@
 #
 
 from mqt.qmap.compile import compile
-from mqt.qmap.pyqmap import Method, InitialLayout, Layering, Arch, CommanderGrouping, SwapReduction, Encoding, Configuration, MappingResults
+from mqt.qmap.pyqmap import Method, InitialLayout, Layering, Arch, CommanderGrouping, SwapReduction, Encoding, Configuration, MappingResults, Architecture
+
+__all__ = ['compile', 'Method', 'InitialLayout', 'Layering', 'Arch', 'CommanderGrouping', 'SwapReduction', 'Encoding', 'Configuration', 'MappingResults', 'Architecture']

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -162,7 +162,6 @@ PYBIND11_MODULE(pyqmap, m) {
 
     py::class_<Configuration>(m, "Configuration", "Configuration options for the MQT QMAP quantum circuit mapping tool")
             .def(py::init<>())
-            .def_readwrite("calibration", &Configuration::calibration)
             .def_readwrite("method", &Configuration::method)
             .def_readwrite("verbose", &Configuration::verbose)
             .def_readwrite("layering", &Configuration::layering)
@@ -195,7 +194,6 @@ PYBIND11_MODULE(pyqmap, m) {
             .def(py::init<>())
             .def_readwrite("input", &MappingResults::input)
             .def_readwrite("output", &MappingResults::output)
-            .def_readwrite("architecture", &MappingResults::architecture)
             .def_readwrite("configuration", &MappingResults::config)
             .def_readwrite("time", &MappingResults::time)
             .def_readwrite("timeout", &MappingResults::timeout)

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -21,7 +21,7 @@ namespace nl = nlohmann;
 using namespace pybind11::literals;
 
 // c++ binding function
-MappingResults map(const py::object& circ, const py::object& arch, Configuration& config) {
+MappingResults map(const py::object& circ, Architecture& arch, Configuration& config) {
     qc::QuantumComputation qc{};
     try {
         if (py::isinstance<py::str>(circ)) {
@@ -36,41 +36,17 @@ MappingResults map(const py::object& circ, const py::object& arch, Configuration
         throw std::invalid_argument(ss.str());
     }
 
-    Architecture architecture{};
-    try {
-        if (py::isinstance<py::str>(arch)) {
-            auto&& cm = arch.cast<std::string>();
-            try {
-                auto available = architectureFromString(cm);
-                architecture.loadCouplingMap(available);
-            } catch (std::exception const& e) {
-                architecture.loadCouplingMap(cm);
-            }
-        } else {
-            auto&& cm = arch.cast<AvailableArchitecture>();
-            architecture.loadCouplingMap(cm);
-        }
-
-        if (!config.calibration.empty()) {
-            architecture.loadCalibrationData(config.calibration);
-        }
-    } catch (std::exception const& e) {
-        std::stringstream ss{};
-        ss << "Could not import architecture: " << e.what();
-        throw std::invalid_argument(ss.str());
-    }
-
     if (config.useTeleportation) {
-        config.teleportationQubits = std::min((architecture.getNqubits() - qc.getNqubits()) & ~1, 8);
+        config.teleportationQubits = std::min((arch.getNqubits() - qc.getNqubits()) & ~1, 8);
     }
 
     std::unique_ptr<Mapper> mapper;
     try {
         if (config.method == Method::Heuristic) {
-            mapper = std::make_unique<HeuristicMapper>(qc, architecture);
+            mapper = std::make_unique<HeuristicMapper>(qc, arch);
         } else if (config.method == Method::Exact) {
 #ifdef Z3_FOUND
-            mapper = std::make_unique<ExactMapper>(qc, architecture);
+            mapper = std::make_unique<ExactMapper>(qc, arch);
 #else
             std::stringstream ss{};
             ss << toString(config.method) << " (Z3 support not enabled)";
@@ -102,7 +78,6 @@ MappingResults map(const py::object& circ, const py::object& arch, Configuration
 
 PYBIND11_MODULE(pyqmap, m) {
     m.doc() = "pybind11 for the MQT QMAP quantum circuit mapping tool";
-    m.def("map", &map, "map a quantum circuit");
 
     py::enum_<AvailableArchitecture>(m, "Arch")
             .value("IBM_QX4", AvailableArchitecture::IBM_QX4)
@@ -215,6 +190,54 @@ PYBIND11_MODULE(pyqmap, m) {
             .def_readwrite("direction_reverse", &MappingResults::CircuitInfo::directionReverse)
             .def_readwrite("teleportations", &MappingResults::CircuitInfo::teleportations);
 
+    auto arch       = py::class_<Architecture>(m, "Architecture", "Class representing device/backend information");
+    auto properties = py::class_<Architecture::Properties>(arch, "Properties", "Class representing properties of an architecture");
+
+    properties.def(py::init<>())
+            .def_property("name", &Architecture::Properties::getName, &Architecture::Properties::setName)
+            .def_property("num_qubits", &Architecture::Properties::getNqubits, &Architecture::Properties::setNqubits)
+            .def("get_single_qubit_error", &Architecture::Properties::getSingleQubitErrorRate, "qubit"_a, "operation"_a)
+            .def("set_single_qubit_error", &Architecture::Properties::setSingleQubitErrorRate, "qubit"_a, "operation"_a, "error_rate"_a)
+            .def("get_two_qubit_error", &Architecture::Properties::getTwoQubitErrorRate, "control"_a, "target"_a, "operation"_a = "cx")
+            .def("set_two_qubit_error", &Architecture::Properties::setTwoQubitErrorRate, "control"_a, "target"_a, "error_rate"_a, "operation"_a = "cx")
+            .def(
+                    "get_readout_error", [](const Architecture::Properties& props, unsigned short qubit) { return props.readoutErrorRate.get(qubit); }, "qubit"_a)
+            .def(
+                    "set_readout_error", [](Architecture::Properties& props, unsigned short qubit, double rate) { props.readoutErrorRate.set(qubit, rate); }, "qubit"_a, "readout_error_rate"_a)
+            .def(
+                    "get_t1", [](const Architecture::Properties& props, unsigned short qubit) { return props.t1Time.get(qubit); }, "qubit"_a)
+            .def(
+                    "set_t1", [](Architecture::Properties& props, unsigned short qubit, double t1) { props.t1Time.set(qubit, t1); }, "qubit"_a, "t1"_a)
+            .def(
+                    "get_t2", [](const Architecture::Properties& props, unsigned short qubit) { return props.t2Time.get(qubit); }, "qubit"_a)
+            .def(
+                    "set_t2", [](Architecture::Properties& props, unsigned short qubit, double t2) { props.t2Time.set(qubit, t2); }, "qubit"_a, "t2"_a)
+            .def(
+                    "get_frequency", [](const Architecture::Properties& props, unsigned short qubit) { return props.qubitFrequency.get(qubit); }, "qubit"_a)
+            .def(
+                    "set_frequency", [](Architecture::Properties& props, unsigned short qubit, double freq) { props.qubitFrequency.set(qubit, freq); }, "qubit"_a, "qubit_frequency"_a)
+            .def(
+                    "get_calibration_date", [](const Architecture::Properties& props, unsigned short qubit) { return props.calibrationDate.get(qubit); }, "qubit"_a)
+            .def(
+                    "set_calibration_date", [](Architecture::Properties& props, unsigned short qubit, const std::string& date) { props.calibrationDate.set(qubit, date); }, "qubit"_a, "calibration_date"_a)
+            .def("json", &Architecture::Properties::json,
+                 "Returns a JSON-style dictionary of all the information present in the :class:`.Properties`")
+            .def("__repr__", &Architecture::Properties::toString,
+                 "Prints a JSON-formatted representation of all the information present in the :class:`.Properties`");
+
+    arch.def(py::init<>())
+            .def(py::init<unsigned short, const CouplingMap&>(), "num_qubits"_a, "coupling_map"_a)
+            .def(py::init<unsigned short, const CouplingMap&, const Architecture::Properties&>(), "num_qubits"_a, "coupling_map"_a, "properties"_a)
+            .def_property("name", &Architecture::getName, &Architecture::setName)
+            .def_property("num_qubits", &Architecture::getNqubits, &Architecture::setNqubits)
+            .def_property("coupling_map", py::overload_cast<>(&Architecture::getCouplingMap), &Architecture::setCouplingMap)
+            .def_property("properties", py::overload_cast<>(&Architecture::getProperties), &Architecture::setProperties)
+            .def("load_coupling_map", py::overload_cast<AvailableArchitecture>(&Architecture::loadCouplingMap), "available_architecture"_a)
+            .def("load_coupling_map", py::overload_cast<const std::string&>(&Architecture::loadCouplingMap), "coupling_map_file"_a)
+            .def("load_properties", py::overload_cast<const Architecture::Properties&>(&Architecture::loadProperties), "properties"_a)
+            .def("load_properties", py::overload_cast<const std::string&>(&Architecture::loadProperties), "properties"_a);
+
+    m.def("map", &map, "map a quantum circuit");
 #ifdef VERSION_INFO
     m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
 #else

--- a/mqt/qmap/compile.py
+++ b/mqt/qmap/compile.py
@@ -75,7 +75,6 @@ def compile(circ, arch: Union[str, Arch],
         circ = pickle.load(open(circ, "rb"))
 
     config = Configuration()
-    config.calibration = calibration
     config.method = Method(method)
     config.initial_layout = InitialLayout(initial_layout)
     config.layering = Layering(layering)

--- a/mqt/qmap/compile.py
+++ b/mqt/qmap/compile.py
@@ -5,11 +5,22 @@
 import pickle
 from pathlib import Path
 from typing import Union, Optional, Set
-from mqt.qmap.pyqmap import map, Method, InitialLayout, Layering, Arch, Encoding, CommanderGrouping, SwapReduction, Configuration, MappingResults
+from mqt.qmap.pyqmap import map, Method, InitialLayout, Layering, Arch, Encoding, CommanderGrouping, SwapReduction, Configuration, MappingResults, Architecture
+
+try:
+    from qiskit.providers import Backend
+    from qiskit.providers.models import BackendProperties
+    from qiskit.transpiler.target import Target
+
+    PossibleArchitectureTypes = Union[str, Arch, Architecture, Backend]
+    PossibleCalibrationTypes = Union[str, BackendProperties, Target]
+except ModuleNotFoundError:
+    PossibleArchitectureTypes = Union[str, Arch, Architecture]
+    PossibleCalibrationTypes = Union[str]
 
 
-def compile(circ, arch: Union[str, Arch],
-            calibration: str = "",
+def compile(circ, arch: PossibleArchitectureTypes,
+            calibration: PossibleCalibrationTypes = "",
             method: Union[str, Method] = "heuristic",
             initial_layout: Union[str, InitialLayout] = "dynamic",
             layering: Union[str, Layering] = "individual_gates",
@@ -30,10 +41,11 @@ def compile(circ, arch: Union[str, Arch],
             ) -> MappingResults:
     """Interface to the MQT QMAP tool for mapping quantum circuits
 
-    :param circ: Path to first circuit file, path to Qiskit QuantumCircuit pickle, or Qiskit QuantumCircuit object
-    :param arch: Path to architecture file or one of the available architectures (Arch)
-    :type arch: Union[str, Arch]
-    :param calibration: Path to file containing calibration information
+    :param circ: Path to circuit file, path to Qiskit QuantumCircuit pickle, or Qiskit QuantumCircuit object
+    :param arch: Architecture to map to. Either a path to a file with architecture information, one of the available architectures (Arch), qmap.Architecture, or `qiskit.providers.backend` (if Qiskit is installed)
+    :type arch: PossibleArchitectureTypes
+    :param calibration: Path to file containing calibration information, `qiskit.providers.models.BackendProperties` object (if Qiskit is installed), or `qiskit.transpiler.target.Target` object (if Qiskit is installed)
+    :type calibration: PossibleCalibrationTypes
     :param method: Mapping technique to use (*heuristic* | exact)
     :type method: Union[str, Method]
     :param initial_layout: Strategy to use for determining initial layout in heuristic mapper (identity | static | *dynamic*)
@@ -74,6 +86,45 @@ def compile(circ, arch: Union[str, Arch],
     if type(circ) == str and Path(circ).suffix == '.pickle':
         circ = pickle.load(open(circ, "rb"))
 
+    architecture = Architecture()
+    if type(arch) == str:
+        try:
+            architecture.load_coupling_map(Arch(arch))
+        except ValueError:
+            architecture.load_coupling_map(arch)
+    elif type(arch) == Arch:
+        architecture.load_coupling_map(arch)
+    elif isinstance(arch, Architecture):
+        architecture = arch
+    else:
+        try:
+            from qiskit.providers.backend import Backend
+            from mqt.qmap.qiskit.backend import import_backend
+            if isinstance(arch, Backend):
+                architecture = import_backend(arch)
+            else:
+                raise ValueError("No compatible type for architecture:", type(arch))
+        except ModuleNotFoundError:
+            raise ValueError("No compatible type for architecture:", type(arch))
+
+    if type(calibration) == str:
+        if calibration != "":
+            architecture.load_properties(calibration)
+    else:
+        try:
+            from qiskit.providers.models import BackendProperties
+            from qiskit.transpiler.target import Target
+            from mqt.qmap.qiskit.backend import import_backend_properties, import_target
+
+            if isinstance(calibration, BackendProperties):
+                architecture.load_properties(import_backend_properties(calibration))
+            elif isinstance(calibration, Target):
+                architecture.load_properties(import_target(calibration))
+            else:
+                raise ValueError("No compatible type for calibration:", type(calibration))
+        except ModuleNotFoundError:
+            raise ValueError("No compatible type for calibration:", type(calibration))
+
     config = Configuration()
     config.method = Method(method)
     config.initial_layout = InitialLayout(initial_layout)
@@ -93,4 +144,4 @@ def compile(circ, arch: Union[str, Arch],
     config.post_mapping_optimizations = post_mapping_optimizations
     config.verbose = verbose
 
-    return map(circ, arch, config)
+    return map(circ, architecture, config)

--- a/mqt/qmap/compile.py
+++ b/mqt/qmap/compile.py
@@ -19,8 +19,8 @@ except ModuleNotFoundError:
     PossibleCalibrationTypes = Union[str]
 
 
-def compile(circ, arch: PossibleArchitectureTypes,
-            calibration: PossibleCalibrationTypes = "",
+def compile(circ, arch: Optional[PossibleArchitectureTypes],
+            calibration: Optional[PossibleCalibrationTypes] = None,
             method: Union[str, Method] = "heuristic",
             initial_layout: Union[str, InitialLayout] = "dynamic",
             layering: Union[str, Layering] = "individual_gates",
@@ -43,9 +43,9 @@ def compile(circ, arch: PossibleArchitectureTypes,
 
     :param circ: Path to circuit file, path to Qiskit QuantumCircuit pickle, or Qiskit QuantumCircuit object
     :param arch: Architecture to map to. Either a path to a file with architecture information, one of the available architectures (Arch), qmap.Architecture, or `qiskit.providers.backend` (if Qiskit is installed)
-    :type arch: PossibleArchitectureTypes
+    :type arch: Optional[PossibleArchitectureTypes]
     :param calibration: Path to file containing calibration information, `qiskit.providers.models.BackendProperties` object (if Qiskit is installed), or `qiskit.transpiler.target.Target` object (if Qiskit is installed)
-    :type calibration: PossibleCalibrationTypes
+    :type calibration: Optional[PossibleCalibrationTypes]
     :param method: Mapping technique to use (*heuristic* | exact)
     :type method: Union[str, Method]
     :param initial_layout: Strategy to use for determining initial layout in heuristic mapper (identity | static | *dynamic*)
@@ -87,43 +87,47 @@ def compile(circ, arch: PossibleArchitectureTypes,
         circ = pickle.load(open(circ, "rb"))
 
     architecture = Architecture()
-    if type(arch) == str:
-        try:
-            architecture.load_coupling_map(Arch(arch))
-        except ValueError:
+    if arch is None and calibration is None:
+        raise ValueError("Either arch or calibration must be specified")
+
+    if arch is not None:
+        if type(arch) == str:
+            try:
+                architecture.load_coupling_map(Arch(arch))
+            except ValueError:
+                architecture.load_coupling_map(arch)
+        elif type(arch) == Arch:
             architecture.load_coupling_map(arch)
-    elif type(arch) == Arch:
-        architecture.load_coupling_map(arch)
-    elif isinstance(arch, Architecture):
-        architecture = arch
-    else:
-        try:
-            from qiskit.providers.backend import Backend
-            from mqt.qmap.qiskit.backend import import_backend
-            if isinstance(arch, Backend):
-                architecture = import_backend(arch)
-            else:
+        elif isinstance(arch, Architecture):
+            architecture = arch
+        else:
+            try:
+                from qiskit.providers.backend import Backend
+                from mqt.qmap.qiskit.backend import import_backend
+                if isinstance(arch, Backend):
+                    architecture = import_backend(arch)
+                else:
+                    raise ValueError("No compatible type for architecture:", type(arch))
+            except ModuleNotFoundError:
                 raise ValueError("No compatible type for architecture:", type(arch))
-        except ModuleNotFoundError:
-            raise ValueError("No compatible type for architecture:", type(arch))
 
-    if type(calibration) == str:
-        if calibration != "":
+    if calibration is not None:
+        if type(calibration) == str:
             architecture.load_properties(calibration)
-    else:
-        try:
-            from qiskit.providers.models import BackendProperties
-            from qiskit.transpiler.target import Target
-            from mqt.qmap.qiskit.backend import import_backend_properties, import_target
+        else:
+            try:
+                from qiskit.providers.models import BackendProperties
+                from qiskit.transpiler.target import Target
+                from mqt.qmap.qiskit.backend import import_backend_properties, import_target
 
-            if isinstance(calibration, BackendProperties):
-                architecture.load_properties(import_backend_properties(calibration))
-            elif isinstance(calibration, Target):
-                architecture.load_properties(import_target(calibration))
-            else:
+                if isinstance(calibration, BackendProperties):
+                    architecture.load_properties(import_backend_properties(calibration))
+                elif isinstance(calibration, Target):
+                    architecture.load_properties(import_target(calibration))
+                else:
+                    raise ValueError("No compatible type for calibration:", type(calibration))
+            except ModuleNotFoundError:
                 raise ValueError("No compatible type for calibration:", type(calibration))
-        except ModuleNotFoundError:
-            raise ValueError("No compatible type for calibration:", type(calibration))
 
     config = Configuration()
     config.method = Method(method)

--- a/mqt/qmap/qiskit/backend.py
+++ b/mqt/qmap/qiskit/backend.py
@@ -1,0 +1,89 @@
+from qiskit.providers import BackendV1, BackendV2, Backend
+from qiskit.providers.models import BackendProperties
+from qiskit.transpiler import Target
+from mqt.qmap import Architecture
+
+
+def import_backend(backend: Backend) -> Architecture:
+    """
+    Import a backend from qiskit.providers.Backend.
+    """
+    if isinstance(backend, BackendV1):
+        return import_backend_v1(backend)
+    elif isinstance(backend, BackendV2):
+        return import_backend_v2(backend)
+    else:
+        raise ValueError('Backend type not supported.')
+
+
+def import_backend_properties(backend_properties: BackendProperties) -> Architecture.Properties:
+    props = Architecture.Properties()
+    props.name = backend_properties.backend_name
+    props.num_qubits = len(backend_properties.qubits)
+    for qubit in range(props.num_qubits):
+        props.set_t1(qubit, backend_properties.t1(qubit))
+        props.set_t2(qubit, backend_properties.t2(qubit))
+        props.set_frequency(qubit, backend_properties.frequency(qubit))
+        props.set_readout_error(qubit, backend_properties.readout_error(qubit))
+
+    for gate in backend_properties.gates:
+        if gate.gate == 'reset':
+            continue
+
+        if len(gate.qubits) == 1:
+            props.set_single_qubit_error(gate.qubits[0], gate.gate, backend_properties.gate_error(gate.gate, gate.qubits))
+        elif len(gate.qubits) == 2:
+            props.set_two_qubit_error(gate.qubits[0], gate.qubits[1], backend_properties.gate_error(gate.gate, gate.qubits), gate.gate)
+    return props
+
+
+def import_backend_v1(backend: BackendV1) -> Architecture:
+    """
+    Import a backend from qiskit.providers.BackendV1.
+    """
+    arch = Architecture()
+    arch.name = backend.name()
+    arch.num_qubits = backend.configuration().n_qubits
+    arch.coupling_map = {(a, b) for a, b in backend.configuration().coupling_map}
+    arch.properties = import_backend_properties(backend.properties())
+
+    return arch
+
+
+def import_target(target: Target) -> Architecture.Properties:
+    props = Architecture.Properties()
+    props.num_qubits = len(target.qubit_properties)
+
+    for i in range(props.num_qubits):
+        qubit_props = target.qubit_properties[i]
+        props.set_t1(i, qubit_props.t1)
+        props.set_t2(i, qubit_props.t2)
+        props.set_frequency(i, qubit_props.frequency)
+
+    for instruction, qargs in target.instructions:
+        if instruction.name == 'reset':
+            continue
+
+        instruction_props = target[instruction.name][qargs]
+        if instruction.name == 'measure':
+            props.set_readout_error(qargs[0], instruction_props.error)
+        elif len(qargs) == 1:
+            props.set_single_qubit_error(qargs[0], instruction.name, instruction_props.error)
+        elif len(qargs) == 2:
+            props.set_two_qubit_error(qargs[0], qargs[1], instruction_props.error, instruction.name)
+
+    return props
+
+
+def import_backend_v2(backend: BackendV2) -> Architecture:
+    """
+    Import a backend from qiskit.providers.BackendV2.
+    """
+    arch = Architecture()
+    arch.name = backend.name
+    arch.num_qubits = backend.num_qubits
+    arch.coupling_map = set(backend.coupling_map.get_edges())
+    arch.properties = import_target(backend.target)
+    arch.properties.name = backend.name
+
+    return arch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,10 @@ build = "cp3*"
 archs = "auto64"
 skip = "*-musllinux*"
 test-skip = "*-macosx_arm64 *-musllinux* *aarch64"
-test-command = "python -c \"from mqt import qmap\""
+test-extras = ["tests"]
+test-command = "python -m pytest {project}/test/python"
 environment = { DEPLOY = "ON" }
+build-frontend = "build"
 build-verbosity = 3
 manylinux-x86_64-image = "manylinux_2_28"
 

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,9 @@ setup(
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
     packages=find_namespace_packages(include=['mqt.*']),
+    extras_require={
+        "tests": ["pytest~=7.1.1", "qiskit-terra>=0.19.2,<0.21.0"],
+    },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
     description='A tool for Quantum Circuit Mapping',
     long_description=README,
     long_description_content_type="text/markdown",
+    python_requires='>=3.7',
     license="MIT",
     url="https://www.cda.cit.tum.de/research/ibm_qx_mapping/",
     ext_modules=[CMakeExtension('pyqmap', namespace='mqt.qmap')],

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -197,9 +197,9 @@ void Architecture::createDistanceTable() {
 
 void Architecture::createFidelityTable() {
     fidelityTable.clear();
-    fidelityTable.resize(nqubits, std::vector<double>(nqubits, 1.0));
+    fidelityTable.resize(nqubits, std::vector<double>(nqubits, 0.0));
 
-    singleQubitFidelities.resize(nqubits, 1.0);
+    singleQubitFidelities.resize(nqubits, 0.0);
 
     for (const auto& [first, second]: couplingMap) {
         if (properties.twoQubitErrorRateAvailable(first, second)) {

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -11,7 +11,7 @@
 
 void Architecture::loadCouplingMap(AvailableArchitecture architecture) {
     std::stringstream ss{getCouplingMapSpecification(architecture)};
-    architectureName = toString(architecture);
+    name = toString(architecture);
     loadCouplingMap(ss);
 }
 
@@ -20,10 +20,10 @@ void Architecture::loadCouplingMap(std::istream& is) {
 }
 
 void Architecture::loadCouplingMap(const std::string& filename) {
-    size_t slash     = filename.find_last_of('/');
-    size_t dot       = filename.find_last_of('.');
-    architectureName = filename.substr(slash + 1, dot - slash - 1);
-    auto ifs         = std::ifstream(filename);
+    size_t slash = filename.find_last_of('/');
+    size_t dot   = filename.find_last_of('.');
+    name         = filename.substr(slash + 1, dot - slash - 1);
+    auto ifs     = std::ifstream(filename);
     if (ifs.good())
         this->loadCouplingMap(ifs);
     else
@@ -32,7 +32,7 @@ void Architecture::loadCouplingMap(const std::string& filename) {
 
 void Architecture::loadCouplingMap(std::istream&& is) {
     couplingMap.clear();
-    calibrationData.clear();
+    properties.clear();
     std::string line;
 
     std::regex  r_nqubits = std::regex("([0-9]+)");
@@ -74,30 +74,32 @@ void Architecture::loadCouplingMap(std::istream&& is) {
 void Architecture::loadCouplingMap(unsigned short nQ, const CouplingMap& cm) {
     nqubits     = nQ;
     couplingMap = cm;
-    calibrationData.clear();
-    architectureName = "generic_" + std::to_string(nQ);
+    properties.clear();
+    name = "generic_" + std::to_string(nQ);
     createDistanceTable();
 }
 
-void Architecture::loadCalibrationData(std::istream& is) {
-    loadCalibrationData(std::move(is));
+void Architecture::loadProperties(std::istream& is) {
+    loadProperties(std::move(is));
 }
 
-void Architecture::loadCalibrationData(const std::string& filename) {
-    size_t slash    = filename.find_last_of('/');
-    size_t dot      = filename.find_last_of('.');
-    calibrationName = filename.substr(slash + 1, dot - slash - 1);
+void Architecture::loadProperties(const std::string& filename) {
+    size_t slash = filename.find_last_of('/');
+    size_t dot   = filename.find_last_of('.');
+    properties.setName(filename.substr(slash + 1, dot - slash - 1));
     if (!isArchitectureAvailable())
-        architectureName = calibrationName;
+        name = properties.getName();
     auto ifs = std::ifstream(filename);
     if (ifs.good())
-        this->loadCalibrationData(ifs);
+        this->loadProperties(ifs);
     else
-        throw QMAPException("Error opening calibration data file.");
+        throw QMAPException("Error opening properties file.");
 }
 
-void Architecture::loadCalibrationData(std::istream&& is) {
-    calibrationData.clear();
+void Architecture::loadProperties(std::istream&& is) {
+    static auto SingleQubitGates = {"id", "u1", "u2", "u3", "rz", "sx", "x"};
+
+    properties.clear();
 
     double averageCNOTFidelity = 0.0;
     int    numCNOTFidelities   = 0;
@@ -112,16 +114,17 @@ void Architecture::loadCalibrationData(std::istream&& is) {
     int qubitNumber = 0;
     while (std::getline(is, line)) {
         std::stringstream        ss(line);
-        CalibrationData          calibrationEntry = {};
         std::vector<std::string> data{};
         parse_line(line, ',', {'\"'}, {'\\'}, data);
-        calibrationEntry.qubit                = qubitNumber;
-        calibrationEntry.t1                   = std::stod(data[1]);
-        calibrationEntry.t2                   = std::stod(data[2]);
-        calibrationEntry.frequency            = std::stod(data[3]);
-        calibrationEntry.readoutError         = std::stod(data[4]);
-        calibrationEntry.singleQubitErrorRate = std::stod(data[5]);
-        std::string s                         = data[6];
+        properties.t1Time.set(qubitNumber, std::stod(data[1]));
+        properties.t2Time.set(qubitNumber, std::stod(data[2]));
+        properties.qubitFrequency.set(qubitNumber, std::stod(data[3]));
+        properties.readoutErrorRate.set(qubitNumber, std::stod(data[4]));
+        // csv file reports average single qubit fidelities
+        for (const auto& operation: SingleQubitGates) {
+            properties.setSingleQubitErrorRate(qubitNumber, operation, std::stod(data[5]));
+        }
+        std::string s = data[6];
         while (std::regex_search(s, sMatch, regexDoubleFidelity)) {
             auto a = static_cast<unsigned short>(std::stoul(sMatch.str(2U)));
             auto b = static_cast<unsigned short>(std::stoul(sMatch.str(3U)));
@@ -129,23 +132,21 @@ void Architecture::loadCalibrationData(std::istream&& is) {
                 couplingMap.emplace(a, b);
             }
             averageCNOTFidelity = averageCNOTFidelity + (std::stod(sMatch.str(4U)) - averageCNOTFidelity) / ++numCNOTFidelities; //calc moving average
-            calibrationEntry.cnotErrors.emplace(std::make_pair(a, b), std::stod(sMatch.str(4U)));
+            properties.setTwoQubitErrorRate(a, b, std::stod(sMatch.str(4U)));
             s = sMatch.suffix().str();
         }
-        calibrationEntry.date = data[7];
-        calibrationData.emplace_back(calibrationEntry);
+        properties.calibrationDate.set(qubitNumber, data[7]);
         qubitNumber++;
     }
 
     if (isArchitectureAvailable())
         for (const auto& edge: couplingMap) {
-            //check if no fidelity for cnot was provided
-            auto calibrationEntry = calibrationData.at(edge.first);
-            if (calibrationEntry.cnotErrors.find(edge) == calibrationEntry.cnotErrors.end()) {
-                calibrationEntry.cnotErrors.emplace(edge, averageCNOTFidelity);
+            if (!properties.twoQubitErrorRateAvailable(edge.first, edge.second)) {
+                properties.setTwoQubitErrorRate(edge.first, edge.second, averageCNOTFidelity);
             }
         }
 
+    properties.setNqubits(qubitNumber);
     if (!isArchitectureAvailable()) {
         nqubits = static_cast<unsigned short>(qubitNumber);
         createDistanceTable();
@@ -154,18 +155,15 @@ void Architecture::loadCalibrationData(std::istream&& is) {
     createFidelityTable();
 }
 
-void Architecture::loadCalibrationData(const std::vector<CalibrationData>& calData) {
+void Architecture::loadProperties(const Properties& props) {
     if (!isArchitectureAvailable()) {
-        for (const auto& cd: calData) {
-            for (const auto& [edge, errorRate]: cd.cnotErrors) {
-                couplingMap.emplace(edge);
-            }
-        }
-        nqubits = calData.size();
+        for (const auto& [control, targetProps]: props.twoQubitErrorRate.get())
+            for (const auto& [target, errorRate]: targetProps.get())
+                couplingMap.emplace(control, target);
+        nqubits = props.getNqubits();
+        name    = "generic_" + std::to_string(nqubits);
     }
-    calibrationData  = calData;
-    architectureName = "generic_" + std::to_string(nqubits);
-    calibrationName  = "generic_" + std::to_string(nqubits);
+    properties = props;
     createFidelityTable();
 }
 
@@ -173,9 +171,9 @@ Architecture::Architecture(unsigned short nQ, const CouplingMap& couplingMap) {
     loadCouplingMap(nQ, couplingMap);
 }
 
-Architecture::Architecture(unsigned short nQ, const CouplingMap& couplingMap, const std::vector<CalibrationData>& calibrationData):
+Architecture::Architecture(unsigned short nQ, const CouplingMap& couplingMap, const Properties& props):
     Architecture(nQ, couplingMap) {
-    loadCalibrationData(calibrationData);
+    loadProperties(props);
 }
 
 void Architecture::createDistanceTable() {
@@ -203,12 +201,14 @@ void Architecture::createFidelityTable() {
 
     singleQubitFidelities.resize(nqubits, 1.0);
 
-    for (const auto& qubit: calibrationData) {
-        for (const auto& entry: qubit.cnotErrors) {
-            fidelityTable.at(entry.first.first).at(entry.first.second) -= entry.second;
+    for (const auto& [first, second]: couplingMap) {
+        if (properties.twoQubitErrorRateAvailable(first, second)) {
+            fidelityTable[first][second] = 1.0 - properties.getTwoQubitErrorRate(first, second);
         }
-        singleQubitFidelities.at(qubit.qubit) -= qubit.singleQubitErrorRate;
     }
+
+    for (const auto& [qubit, operationProps]: properties.singleQubitErrorRate.get())
+        singleQubitFidelities[qubit] = 1.0 - properties.getAverageSingleQubitErrorRate(qubit);
 }
 
 unsigned long Architecture::minimumNumberOfSwaps(std::vector<unsigned short>& permutation, long limit) {
@@ -518,8 +518,7 @@ void Architecture::findCouplingLimit(unsigned short node, int curSum, const std:
 }
 
 void Architecture::getHighestFidelityCouplingMap(unsigned short subsetSize, CouplingMap& reducedMap) {
-    if (!isArchitectureAvailable() || nqubits == subsetSize ||
-        calibrationName.empty()) {
+    if (!isArchitectureAvailable() || nqubits == subsetSize || properties.empty()) {
         reducedMap = couplingMap;
     } else {
         double bestFidelity        = 0.0;
@@ -529,7 +528,7 @@ void Architecture::getHighestFidelityCouplingMap(unsigned short subsetSize, Coup
             double      currentFidelity{};
             CouplingMap map{};
             getReducedCouplingMap(qubitChoice, map);
-            currentFidelity = getAverageArchitectureFidelity(map, qubitChoice, calibrationData);
+            currentFidelity = getAverageArchitectureFidelity(map, qubitChoice, properties);
             if (currentFidelity > bestFidelity) {
                 reducedMap   = map;
                 bestFidelity = currentFidelity;
@@ -579,20 +578,21 @@ void Architecture::getReducedCouplingMap(const std::set<unsigned short>& qubitCh
     }
 }
 
-double Architecture::getAverageArchitectureFidelity(const CouplingMap& couplingMap, const std::set<unsigned short>& qubitChoice, const std::vector<CalibrationData>& calibrationData) {
-    if (calibrationData.empty()) {
+double Architecture::getAverageArchitectureFidelity(const CouplingMap& cm, const std::set<unsigned short>& qubitChoice, const Properties& props) {
+    if (props.empty()) {
         return 0.0;
     }
-    double         result = 1.0;
-    std::set<Edge> qubitPairs{};
-    getReducedCouplingMap(qubitChoice, qubitPairs);
-    for (const auto& calibrationEntry: calibrationData) {
-        for (const auto& edge: couplingMap) {
-            if (calibrationEntry.cnotErrors.find(edge) != calibrationEntry.cnotErrors.end())
-                result *= calibrationEntry.cnotErrors.at(edge);
+    double result = 1.0;
+    for (const auto& [control, target]: cm) {
+        if (props.twoQubitErrorRateAvailable(control, target)) {
+            result *= props.getTwoQubitErrorRate(control, target);
         }
-        if (qubitChoice.find(calibrationEntry.qubit) != qubitChoice.end())
-            result *= calibrationEntry.singleQubitErrorRate;
+    }
+
+    for (const auto& qubit: qubitChoice) {
+        if (props.singleQubitErrorRate.available(qubit)) {
+            result *= props.getAverageSingleQubitErrorRate(qubit);
+        }
     }
     return result;
 }

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -162,6 +162,7 @@ void Architecture::loadProperties(const Properties& props) {
                 couplingMap.emplace(control, target);
         nqubits = props.getNqubits();
         name    = "generic_" + std::to_string(nqubits);
+        createDistanceTable();
     }
     properties = props;
     createFidelityTable();

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -139,13 +139,13 @@ void Architecture::loadProperties(std::istream&& is) {
         qubitNumber++;
     }
 
-    if (isArchitectureAvailable())
+    if (isArchitectureAvailable()) {
         for (const auto& edge: couplingMap) {
             if (!properties.twoQubitErrorRateAvailable(edge.first, edge.second)) {
                 properties.setTwoQubitErrorRate(edge.first, edge.second, averageCNOTFidelity);
             }
         }
-
+    }
     properties.setNqubits(qubitNumber);
     if (!isArchitectureAvailable()) {
         nqubits = static_cast<unsigned short>(qubitNumber);
@@ -157,9 +157,11 @@ void Architecture::loadProperties(std::istream&& is) {
 
 void Architecture::loadProperties(const Properties& props) {
     if (!isArchitectureAvailable()) {
-        for (const auto& [control, targetProps]: props.twoQubitErrorRate.get())
-            for (const auto& [target, errorRate]: targetProps.get())
+        for (const auto& [control, targetProps]: props.twoQubitErrorRate.get()) {
+            for (const auto& [target, errorRate]: targetProps.get()) {
                 couplingMap.emplace(control, target);
+            }
+        }
         nqubits = props.getNqubits();
         name    = "generic_" + std::to_string(nqubits);
         createDistanceTable();

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -585,13 +585,13 @@ double Architecture::getAverageArchitectureFidelity(const CouplingMap& cm, const
     double result = 1.0;
     for (const auto& [control, target]: cm) {
         if (props.twoQubitErrorRateAvailable(control, target)) {
-            result *= props.getTwoQubitErrorRate(control, target);
+            result *= (1.0 - props.getTwoQubitErrorRate(control, target));
         }
     }
 
     for (const auto& qubit: qubitChoice) {
         if (props.singleQubitErrorRate.available(qubit)) {
-            result *= props.getAverageSingleQubitErrorRate(qubit);
+            result *= (1.0 - props.getAverageSingleQubitErrorRate(qubit));
         }
     }
     return result;

--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -11,7 +11,7 @@ void Mapper::initResults() {
     countGates(qc, results.input);
     results.input.name    = qc.getName();
     results.input.qubits  = qc.getNqubits();
-    results.architecture  = architecture.getArchitectureName();
+    results.architecture  = &architecture;
     results.output.name   = qc.getName() + "_mapped";
     results.output.qubits = architecture.getNqubits();
     results.output.gates  = std::numeric_limits<unsigned long>::max();

--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -11,7 +11,7 @@ void Mapper::initResults() {
     countGates(qc, results.input);
     results.input.name    = qc.getName();
     results.input.qubits  = qc.getNqubits();
-    results.architecture  = &architecture;
+    results.architecture  = architecture.getName();
     results.output.name   = qc.getName() + "_mapped";
     results.output.qubits = architecture.getNqubits();
     results.output.gates  = std::numeric_limits<unsigned long>::max();

--- a/test/python/test.py
+++ b/test/python/test.py
@@ -1,0 +1,19 @@
+from qiskit import QuantumCircuit
+from qiskit.test.mock.backends import FakeLondon
+
+from mqt import qmap
+
+if __name__ == '__main__':
+    qc = QuantumCircuit(3)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.cx(1, 2)
+    qc.measure_all()
+    print(qc.draw(fold=-1))
+
+    # compile the circuit
+    results = qmap.compile(qc, arch=FakeLondon())
+
+    # get the mapped circuit
+    qc_mapped = QuantumCircuit.from_qasm_str(results.mapped_circuit)
+    print(qc_mapped.draw(fold=-1))

--- a/test/python/test_qiskit_backend_imports.py
+++ b/test/python/test_qiskit_backend_imports.py
@@ -1,0 +1,57 @@
+import pytest
+from qiskit import QuantumCircuit
+from qiskit.test.mock.backends import FakeLondon, FakeLondonV2, FakeAthens, FakeAthensV2
+
+from mqt import qmap
+
+
+@pytest.fixture
+def example_circuit() -> QuantumCircuit:
+    qc = QuantumCircuit(3)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.cx(1, 2)
+    qc.measure_all()
+    return qc
+
+
+def test_old_backend_v1(example_circuit: QuantumCircuit):
+    """Test that circuits can be mapped to Qiskit BackendV1 instances providing the old basis_gates."""
+    results = qmap.compile(example_circuit, arch=FakeLondon())
+    assert results.timeout is False
+    assert results.mapped_circuit != ""
+
+
+def test_old_backend_v2(example_circuit: QuantumCircuit):
+    """Test that circuits can be mapped to Qiskit BackendV2 instances providing the old basis_gates."""
+    results = qmap.compile(example_circuit, arch=FakeLondonV2())
+    assert results.timeout is False
+    assert results.mapped_circuit != ""
+
+
+def test_new_backend_v1(example_circuit: QuantumCircuit):
+    """Test that circuits can be mapped to Qiskit BackendV1 instances providing the new basis_gates."""
+    results = qmap.compile(example_circuit, arch=FakeAthens())
+    assert results.timeout is False
+    assert results.mapped_circuit != ""
+
+
+def test_new_backend_v2(example_circuit: QuantumCircuit):
+    """Test that circuits can be mapped to Qiskit BackendV2 instances providing the new basis_gates."""
+    results = qmap.compile(example_circuit, arch=FakeAthensV2())
+    assert results.timeout is False
+    assert results.mapped_circuit != ""
+
+
+def test_architecture_from_v1_backend_properties(example_circuit: QuantumCircuit):
+    """Test that circuits can be mapped by simply providing the backend properties (the BackendV1 way)."""
+    results = qmap.compile(example_circuit, arch=None, calibration=FakeLondon().properties())
+    assert results.timeout is False
+    assert results.mapped_circuit != ""
+
+
+def test_architecture_from_v2_target(example_circuit: QuantumCircuit):
+    """Test that circuits can be mapped by simply providing the target (the BackendV2 way)."""
+    results = qmap.compile(example_circuit, arch=None, calibration=FakeLondonV2().target)
+    assert results.timeout is False
+    assert results.mapped_circuit != ""

--- a/test/test_architecture.cpp
+++ b/test/test_architecture.cpp
@@ -29,7 +29,7 @@ TEST_P(TestArchitecture, QubitMap) {
         arch.loadCouplingMap(ss.str());
     } else {
         ss << test_calibration_dir << arch_name;
-        arch.loadCalibrationData(ss.str());
+        arch.loadProperties(ss.str());
     }
 
     EXPECT_EQ(Architecture::getQubitList(arch.getCouplingMap()).size(), arch.getNqubits());
@@ -43,7 +43,7 @@ TEST_P(TestArchitecture, GetAllConnectedSubsets) {
         arch.loadCouplingMap(ss.str());
     } else {
         ss << test_calibration_dir << arch_name;
-        arch.loadCalibrationData(ss.str());
+        arch.loadProperties(ss.str());
     }
 
     EXPECT_EQ(arch.getAllConnectedSubsets(arch.getNqubits()).size(), 1);
@@ -58,7 +58,7 @@ TEST_P(TestArchitecture, GetHighestFidelity) {
         arch.loadCouplingMap(ss.str());
     } else {
         ss << test_calibration_dir << arch_name;
-        arch.loadCalibrationData(ss.str());
+        arch.loadProperties(ss.str());
     }
     CouplingMap cm{};
 
@@ -85,7 +85,7 @@ TEST_P(TestArchitecture, ReducedMaps) {
         arch.loadCouplingMap(ss.str());
     } else {
         ss << test_calibration_dir << arch_name;
-        arch.loadCalibrationData(ss.str());
+        arch.loadProperties(ss.str());
     }
 
     std::vector<CouplingMap> cms;
@@ -119,42 +119,30 @@ TEST(TestArchitecture, ConnectedTest) {
 }
 
 TEST(TestArchitecture, FidelityTest) {
-    Architecture                               architecture{};
-    CouplingMap                                cm{};
-    std::vector<Architecture::CalibrationData> calibrationData{};
+    Architecture architecture{};
+    CouplingMap  cm{};
 
-    Architecture::CalibrationData data{};
-    data.qubit                = 0;
-    data.singleQubitErrorRate = 0.9;
-    data.cnotErrors.emplace(std::make_pair(0, 1), 0.8);
-    calibrationData.push_back(data);
-    data.qubit                = 1;
-    data.singleQubitErrorRate = 0.9;
-    data.cnotErrors.emplace(std::make_pair(1, 0), 0.8);
-    data.cnotErrors.emplace(std::make_pair(1, 2), 0.7);
-    calibrationData.push_back(data);
-    data.qubit                = 2;
-    data.singleQubitErrorRate = 0.9;
-    data.cnotErrors.emplace(std::make_pair(2, 1), 0.7);
-    data.cnotErrors.emplace(std::make_pair(2, 3), 0.6);
-    calibrationData.push_back(data);
-    data.qubit                = 3;
-    data.singleQubitErrorRate = 0.9;
-    data.cnotErrors.emplace(std::make_pair(3, 2), 0.6);
-    calibrationData.push_back(data);
+    auto props = Architecture::Properties();
+    props.setNqubits(4);
+    props.setSingleQubitErrorRate(0, "x", 0.9);
+    props.setSingleQubitErrorRate(1, "x", 0.9);
+    props.setSingleQubitErrorRate(2, "x", 0.9);
+    props.setSingleQubitErrorRate(3, "x", 0.9);
 
-    architecture.loadCalibrationData(calibrationData);
+    props.setTwoQubitErrorRate(0, 1, 0.8);
+    props.setTwoQubitErrorRate(1, 0, 0.8);
+    props.setTwoQubitErrorRate(1, 2, 0.7);
+    props.setTwoQubitErrorRate(2, 1, 0.7);
+    props.setTwoQubitErrorRate(2, 3, 0.6);
+    props.setTwoQubitErrorRate(3, 2, 0.6);
 
+    architecture.loadProperties(props);
     architecture.getHighestFidelityCouplingMap(2, cm);
 
-    std::vector<unsigned short> highestFidelity{};
-    highestFidelity.push_back(2);
-    highestFidelity.push_back(3);
+    std::vector<unsigned short> highestFidelity{2, 3};
+    auto                        qubitList = Architecture::getQubitList(cm);
 
-    auto qubitList = Architecture::getQubitList(cm);
-
-    ASSERT_TRUE((qubitList.size() == highestFidelity.size() &&
-                 std::equal(qubitList.begin(), qubitList.end(), highestFidelity.begin())));
+    EXPECT_EQ(qubitList, highestFidelity);
 }
 
 TEST(TestArchitecture, FullyConnectedTest) {

--- a/test/test_exact.cpp
+++ b/test/test_exact.cpp
@@ -36,7 +36,7 @@ protected:
         }
         IBMQ_Yorktown.loadCouplingMap(AvailableArchitecture::IBMQ_Yorktown);
         IBMQ_London.loadCouplingMap(test_architecture_dir + "ibmq_london.arch");
-        IBMQ_London.loadCalibrationData(test_calibration_dir + "ibmq_london.csv");
+        IBMQ_London.loadProperties(test_calibration_dir + "ibmq_london.csv");
         IBM_QX4.loadCouplingMap(AvailableArchitecture::IBM_QX4);
 
         IBMQ_Yorktown_mapper = std::make_unique<ExactMapper>(qc, IBMQ_Yorktown);

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -24,7 +24,7 @@ protected:
         qc.import(test_example_dir + GetParam() + ".qasm");
         IBMQ_Yorktown.loadCouplingMap(AvailableArchitecture::IBMQ_Yorktown);
         IBMQ_London.loadCouplingMap(test_architecture_dir + "ibmq_london.arch");
-        IBMQ_London.loadCalibrationData(test_calibration_dir + "ibmq_london.csv");
+        IBMQ_London.loadProperties(test_calibration_dir + "ibmq_london.csv");
         IBMQ_Yorktown_mapper = std::make_unique<HeuristicMapper>(qc, IBMQ_Yorktown);
         IBMQ_London_mapper   = std::make_unique<HeuristicMapper>(qc, IBMQ_London);
     }


### PR DESCRIPTION
This PR brings native support for using Qiskit Backends (e.g., `FakeLondon()`) as architectures in QMAP.
To this end, native translation is provided for all backends implementing either the `BackendV1` or them oder `BackendV2` interface.
In addition to that, QMAP can now als natively read device properties from Qiskit backends, either via the `BackendProperties` class or the modern `Target` class.
In the process, the way device properties and/or calibration data is handled in QMAP has been completely refactored.
This should make it easier to incorporate this information into the available mapping passes in the future.

Solves #12 🥳 