### PR TITLE
📝 Initialize Documentation on ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+version: 2
+
+submodules:
+  include:   all
+  recursive: true
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+  apt_packages:
+    - cmake
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - method: pip
+      path:   .
+      extra_requirements:
+        - docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,68 @@
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata
+
+import pybtex.plugin
+from pybtex.style.formatting.unsrt import Style as UnsrtStyle
+from pybtex.style.template import field, href
+
+# -- Project information -----------------------------------------------------
+project = "QMAP"
+author = "Lukas Burgholzer"
+
+release = metadata.version("mqt.qmap")
+version = ".".join(release.split(".")[:3])
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosectionlabel",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.githubpages",
+    "sphinxcontrib.bibtex",
+    "sphinx_copybutton",
+    "hoverxref.extension",
+]
+
+autosectionlabel_prefix_document = True
+
+hoverxref_auto_ref = True
+hoverxref_domains = ["cite", "py"]
+hoverxref_roles = []
+hoverxref_mathjax = True
+hoverxref_role_types = {
+    "ref": "tooltip",
+    "p": "tooltip",
+    "labelpar": "tooltip",
+    "class": "tooltip",
+    "meth": "tooltip",
+    "func": "tooltip",
+    "attr": "tooltip",
+    "property": "tooltip",
+}
+
+
+class CDAStyle(UnsrtStyle):
+    def format_url(self, e):
+        url = field("url", raw=True)
+        return href()[url, "[PDF]"]
+
+
+pybtex.plugin.register_plugin("pybtex.style.formatting", "cda_style", CDAStyle)
+
+bibtex_bibfiles = ["refs.bib"]
+bibtex_default_style = "cda_style"
+
+copybutton_prompt_text = r"(?:\(venv\) )?\$ "
+copybutton_prompt_is_regexp = True
+copybutton_line_continuation_character = "\\"
+
+autosummary_generate = True
+
+# -- Options for HTML output -------------------------------------------------
+html_theme = "sphinx_rtd_theme"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,4 @@
+Welcome to QMAP's documentation!
+================================
+
+At the moment, this documentation is just blank. Expect this to change in the near future.

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1,0 +1,37 @@
+@article{zulehnerEfficientMethodologyMapping2019,
+    author = {Alwin Zulehner and Alexandru Paler and Robert Wille},
+    title = {An Efficient Methodology for Mapping Quantum Circuits to the {IBM QX} Architectures},
+    journal = {{IEEE} Transactions on Computer-Aided Design of Integrated Circuits and Systems},
+    volume = {38},
+    number = {7},
+    pages = {1226--1236},
+    year = {2019},
+    url = {https://www.cda.cit.tum.de/files/eda/2018_tcad_efficient_mapping_of_quantum_circuits_to_ibm_qx_architectures.pdf},
+}
+
+@inproceedings{willeMappingQuantumCircuits2019,
+    author = {Wille, Robert and Burgholzer, Lukas and Zulehner, Alwin},
+    booktitle = {Design Automation Conference},
+    month = {June},
+    title = {Mapping quantum circuits to {IBM QX} architectures using the minimal number of {SWAP} and {H} operations},
+    year = {2019},
+    url = {https://www.cda.cit.tum.de/files/eda/2019_dac_mapping_quantum_circuits_ibm_architectures_using_minimal_number_swap_h_gates.pdf},
+}
+
+@inproceedings{hillmichExlpoitingQuantumTeleportation2021,
+    author = {Stefan Hillmich and Alwin Zulehner and Robert Wille},
+    title = {Exploiting Quantum Teleportation in Quantum Circuit Mapping},
+    booktitle = {Asia and South Pacific Design Automation Conference},
+    pages = {792--797},
+    year = {2021},
+    url = {https://www.cda.cit.tum.de/files/eda/2021_aspdac_exploiting_teleportation_in_quantum_circuit_mappping.pdf},
+}
+
+@inproceedings{burgholzerRandomStimuliGeneration2021,
+    author = {Burgholzer, Lukas and Schneider, Sarah and Wille, Robert},
+    booktitle = {Asia and South Pacific Design Automation Conference},
+    month = {January},
+    title = {Limiting the Search Space in Optimal Quantum Circuit Mapping},
+    year = {2022},
+    url = {https://www.cda.cit.tum.de/files/eda/2022_aspdac_limiting_search_space_optimal_quantum_circuit_mapping.pdf},
+}

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import nox
+from nox.sessions import Session
+
+
+@nox.session
+def docs(session: Session) -> None:
+    """Build the documentation. Simply execute `nox -rs docs -- serve` to locally build and serve the docs."""
+    session.install(".[docs]")
+    session.chdir("docs")
+    session.run("sphinx-build", "-M", "html", "source", "_build")
+
+    if session.posargs:
+        if "serve" in session.posargs:
+            print("Launching docs at http://localhost:8000/ - use Ctrl-C to quit")
+            session.run("python", "-m", "http.server", "8000", "-d", "_build/html")
+        else:
+            print("Unsupported argument to docs")

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,16 @@ setup(
     install_requires=["qiskit-terra>=0.20.2,<0.22.0"],
     extras_require={
         "test": ["pytest~=7.1.1", "mqt.qcec~=2.0.0rc4"],
-        "dev": ["mqt.qmap[test]"]  # requires Pip 21.2 or newer
+        "docs": [
+            "sphinx>=5.1.1",
+            "sphinx-rtd-theme",
+            "sphinxcontrib-bibtex~=2.5",
+            "sphinx-copybutton",
+            "sphinx-hoverxref~=1.1.3",
+            "pybtex>=0.24",
+            "importlib_metadata>=3.6; python_version < '3.10'",
+        ],
+        "dev": ["mqt.qmap[test, docs]"]  # requires Pip 21.2 or newer
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -130,5 +139,6 @@ setup(
         'Source': 'https://github.com/cda-tum/qmap/',
         'Tracker': 'https://github.com/cda-tum/qmap/issues',
         'Research': 'https://www.cda.cit.tum.de/research/ibm_qx_mapping/',
+        'Documentation': 'https://qmap.readthedocs.io',
     }
 )


### PR DESCRIPTION
This PR adds the initial configuration and infrastructure for building proper project documentation on ReadTheDocs.

Building the documentation locally is as easy as
```console
nox -rs docs -- serve
```

> `nox` is best installed via `pipx install nox` (or `brew install nox` if you are on macOS). If you don't have `pipx` (pip for applications) you can install it with `pip install pipx` (or `brew install pipx` if you are on macOS).

At the moment the documentation is pretty much empty. Filling it with content will be done in a separate PR.