### PR TITLE
🔧 Fix RtD Documentation Setup

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,10 +11,8 @@ build:
   apt_packages:
     - cmake
   jobs:
-    pre_build:
+    pre_install:
       - python -m pip install z3-solver
-      - export Z3_ROOT=$(python -c "import z3, os; print(os.path.dirname(z3.__file__))")
-      - export Z3_DIR=$(python -c "import z3, os; print(os.path.dirname(z3.__file__))")
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,11 +5,16 @@ submodules:
   recursive: true
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.9"
   apt_packages:
     - cmake
+  jobs:
+    pre_build:
+      - python -m pip install z3-solver
+      - export Z3_ROOT=$(python -c "import z3, os; print(os.path.dirname(z3.__file__))")
+      - export Z3_DIR=$(python -c "import z3, os; print(os.path.dirname(z3.__file__))")
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,9 +10,6 @@ build:
     python: "3.9"
   apt_packages:
     - cmake
-  jobs:
-    pre_install:
-      - python -m pip install z3-solver
 
 sphinx:
   configuration: docs/source/conf.py

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,6 @@ setup(
         'Source': 'https://github.com/cda-tum/qmap/',
         'Tracker': 'https://github.com/cda-tum/qmap/issues',
         'Research': 'https://www.cda.cit.tum.de/research/ibm_qx_mapping/',
-        'Documentation': 'https://qmap.readthedocs.io',
+        'Documentation': 'https://mqtqmap.readthedocs.io',
     }
 )


### PR DESCRIPTION
Now that the foundation has been laid in #98, it is time to get things to work properly. 
Of course, the build failed right away because no proper version of Z3 was available for the documentation build.
This PR fixes these build errors by updating the Ubuntu image used to build the docs.
The updated image (Ubuntu-22.04) comes with a recent enough z3 version to build QMAP.