### PR TITLE
✨ Optionally disable measurements

### DIFF
--- a/include/configuration/Configuration.hpp
+++ b/include/configuration/Configuration.hpp
@@ -23,6 +23,8 @@ struct Configuration {
     bool preMappingOptimizations  = true;
     bool postMappingOptimizations = true;
 
+    bool addMeasurementsToMappedCircuit = true;
+
     bool verbose = false;
 
     // map to particular subgraph of architecture (in exact mapper)
@@ -73,9 +75,10 @@ struct Configuration {
         if (!subgraph.empty()) {
             config["subgraph"] = subgraph;
         }
-        config["pre_mapping_optimizations"]  = preMappingOptimizations;
-        config["post_mapping_optimizations"] = postMappingOptimizations;
-        config["verbose"]                    = verbose;
+        config["pre_mapping_optimizations"]          = preMappingOptimizations;
+        config["post_mapping_optimizations"]         = postMappingOptimizations;
+        config["add_measurements_to_mapped_circuit"] = addMeasurementsToMappedCircuit;
+        config["verbose"]                            = verbose;
 
         if (method == Method::Heuristic) {
             auto& heuristic             = config["settings"];

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -162,6 +162,7 @@ PYBIND11_MODULE(pyqmap, m) {
             .def_readwrite("subgraph", &Configuration::subgraph)
             .def_readwrite("pre_mapping_optimizations", &Configuration::preMappingOptimizations)
             .def_readwrite("post_mapping_optimizations", &Configuration::postMappingOptimizations)
+            .def_readwrite("add_measurements_to_mapped_circuit", &Configuration::addMeasurementsToMappedCircuit)
             .def("json", &Configuration::json)
             .def("__repr__", &Configuration::toString);
 

--- a/mqt/qmap/compile.py
+++ b/mqt/qmap/compile.py
@@ -70,6 +70,7 @@ def compile(
     subgraph: Optional[Set[int]] = None,
     pre_mapping_optimizations: bool = True,
     post_mapping_optimizations: bool = True,
+    add_measurements_to_mapped_circuit: bool = True,
     verbose: bool = False,
 ) -> Tuple[QuantumCircuit, MappingResults]:
     """Interface to the MQT QMAP tool for mapping quantum circuits
@@ -109,6 +110,8 @@ def compile(
     :type pre_mapping_optimizations: bool
     :param post_mapping_optimizations: Run post-mapping optimizations (default: True)
     :type post_mapping_optimizations: bool
+    :param add_measurements_to_mapped_circuit: Whether to add measurements at the end of the mapped circuit (default: True)
+    :type add_measurements_to_mapped_circuit: bool
     :param verbose: Print more detailed information during the mapping process
     :type verbose: bool
     :return: Mapped circuit (as Qiskit `QuantumCircuit`) and results
@@ -174,6 +177,7 @@ def compile(
     config.teleportation_seed = teleportation_seed
     config.pre_mapping_optimizations = pre_mapping_optimizations
     config.post_mapping_optimizations = post_mapping_optimizations
+    config.add_measurements_to_mapped_circuit = add_measurements_to_mapped_circuit
     config.verbose = verbose
 
     results = map(circ, architecture, config)

--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -158,7 +158,9 @@ void Mapper::finalizeMappedCircuit() {
     qcMapped.unifyQuantumRegisters();
 
     // append measurements according to output permutation
-    qcMapped.appendMeasurementsAccordingToOutputPermutation();
+    if (results.config.addMeasurementsToMappedCircuit) {
+        qcMapped.appendMeasurementsAccordingToOutputPermutation();
+    }
 }
 
 void Mapper::placeRemainingArchitectureQubits() {

--- a/test/test_exact.cpp
+++ b/test/test_exact.cpp
@@ -471,3 +471,21 @@ TEST_F(ExactTest, CommanderEncodingRigettiArch) {
 
     SUCCEED() << "Mapping successful";
 }
+
+TEST_F(ExactTest, NoMeasurmentsAdded) {
+    // configure to not include measurements after mapping
+    settings.addMeasurementsToMappedCircuit = false;
+
+    // perform the mapping
+    IBMQ_London_mapper->map(settings);
+
+    // get the resulting circuit
+    auto              qcMapped = qc::QuantumComputation();
+    std::stringstream qasm{};
+    IBMQ_London_mapper->dumpResult(qasm, qc::OpenQASM);
+    qcMapped.import(qasm, qc::OpenQASM);
+
+    // check no measurements were added
+    EXPECT_EQ(qcMapped.getNops(), 4U);
+    EXPECT_NE(qcMapped.back()->getType(), qc::Measure);
+}


### PR DESCRIPTION
This PR adds a new option `add_measurements_to_mapped_circuit` to the QMAP configuration that allows to specify whether measurements should be included in the final circuit or not (defaults to `True`). Using it is as simple as

```python3
from mqt import qmap

qcMapped, result = qmap.compile(qc, arch, add_measurements_to_mapped_circuit=False)
```

Closes #102.