### PR TITLE
🔧 Proper Versioning in Deploy CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.9.0
       - uses: actions/upload-artifact@v3
@@ -36,6 +37,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
       - name: Install Z3
         run: brew install z3
       - name: Build wheels
@@ -52,6 +54,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
       - name: Install Z3
         run: |
           curl -L -H "Authorization: Bearer QQ==" -o ${{ env.Z3_GIT_TAG }}.big_sur.bottle.tar.gz https://ghcr.io/v2/homebrew/core/z3/blobs/sha256:${{ env.Z3_HASH }}
@@ -72,6 +75,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Cache Z3
         id: cache-z3
@@ -103,6 +107,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         name: Install Python
         with:


### PR DESCRIPTION
This PR adds `fetch-depth: 0` to all checkouts in the deploy workflow.
This is required for `setuptools-scm` to properly infer a proper version number for non-tagged commits (it always infers `mqt.qmap-0.1.dev1` if no commit history with tags is available).
While only a minor improvement, it should allow to catch a few more python packaging errors that might appear in the future.

