### PR TITLE
🔧 Update CodeQL configuration

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,4 @@
+name: GitHub CodeQL Config
+
+queries:
+  - uses: security-and-quality

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Installing boost
-        run:  sudo apt-get install -y libboost-program-options-dev
+        run: sudo apt-get install -y libboost-program-options-dev
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
@@ -55,9 +55,9 @@ jobs:
         uses: advanced-security/filter-sarif@main
         with:
           patterns: |
-                    -**/extern/**
-          input:    sarif-results/${{ matrix.language }}.sarif
-          output:   sarif-results/${{ matrix.language }}.sarif
+            -**/extern/**
+          input: sarif-results/${{ matrix.language }}.sarif
+          output: sarif-results/${{ matrix.language }}.sarif
 
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,71 +10,56 @@ on:
 
 jobs:
   analyze-cpp:
-    name: Analyze C++
-    runs-on: ubuntu-latest
+    name: Analyze
+    runs-on: ubuntu-22.04
     permissions:
-      actions: read
-      contents: read
       security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["cpp", "python"]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           submodules: recursive
-
-      # Initializes the CodeQL tools for scanning.
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: "cpp"
-
-      - uses: actions/setup-python@v4
-        name: Install Python
-        with:
-          python-version: "3.10"
+          fetch-depth: 0
 
       - name: Installing boost
-        run: sudo apt-get install -y libboost-program-options-dev
-
-      - name: Install Z3
-        run: python -m pip install z3-solver
-
-      - name: Configure CMake
-        run: |
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$pythonLocation/lib/python3.10/site-packages/z3/lib
-          export Z3_ROOT=$pythonLocation/lib/python3.10/site-packages/z3
-          export Z3_DIR=$pythonLocation/lib/python3.10/site-packages/z3
-          cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=Release -DBUILD_QMAP_TESTS=ON -DBINDINGS=ON
-
-      - name: Build
-        run: cmake --build "${{github.workspace}}/build" --parallel 4
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
-
-  analyze-python:
-    name: Analyze Python
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
+        run:  sudo apt-get install -y libboost-program-options-dev
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
-          languages: "python"
+          languages: ${{ matrix.language }}
+          config-file: .github/codeql-config.yml
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+      - if: matrix.language == 'cpp'
+        name: Configure CMake
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_QMAP_TESTS=ON -DBINDINGS=ON
+
+      - if: matrix.language == 'cpp'
+        name: Build
+        run: cmake --build build --parallel 4
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
+        with:
+          upload: False
+          output: sarif-results
+
+      - name: filter-sarif
+        uses: advanced-security/filter-sarif@main
+        with:
+          patterns: |
+                    -**/extern/**
+          input:    sarif-results/${{ matrix.language }}.sarif
+          output:   sarif-results/${{ matrix.language }}.sarif
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: sarif-results/${{ matrix.language }}.sarif

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -178,7 +178,7 @@ inline bool operator<(const HeuristicMapper::Node& x, const HeuristicMapper::Nod
 inline bool operator>(const HeuristicMapper::Node& x, const HeuristicMapper::Node& y) {
     const auto xcost = x.costTotal + static_cast<double>(x.costFixed) + x.lookaheadPenalty;
     const auto ycost = y.costTotal + static_cast<double>(y.costFixed) + y.lookaheadPenalty;
-    if (std::abs(xcost - ycost) < 1e-6) {
+    if (std::abs(xcost - ycost) > 1e-6) {
         return xcost > ycost;
     }
 
@@ -191,7 +191,7 @@ inline bool operator>(const HeuristicMapper::Node& x, const HeuristicMapper::Nod
 
     const auto xheur = x.costHeur + x.lookaheadPenalty;
     const auto yheur = y.costHeur + y.lookaheadPenalty;
-    if (std::abs(xheur - yheur) < 1e-6) {
+    if (std::abs(xheur - yheur) > 1e-6) {
         return xheur > yheur;
     } else {
         return x < y;

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -132,6 +132,7 @@ protected:
     unique_priority_queue<Node> nodes{};
 
     virtual void createInitialMapping();
+    virtual void staticInitialMapping();
 
     double distanceOnArchitectureOfLogicalQubits(unsigned short control, unsigned short target) {
         return architecture.distance(locations.at(control), locations.at(target));

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -175,9 +175,9 @@ inline bool operator<(const HeuristicMapper::Node& x, const HeuristicMapper::Nod
 }
 
 inline bool operator>(const HeuristicMapper::Node& x, const HeuristicMapper::Node& y) {
-    auto xcost = x.costTotal + static_cast<double>(x.costFixed) + x.lookaheadPenalty;
-    auto ycost = y.costTotal + static_cast<double>(y.costFixed) + y.lookaheadPenalty;
-    if (xcost != ycost) {
+    const auto xcost = x.costTotal + static_cast<double>(x.costFixed) + x.lookaheadPenalty;
+    const auto ycost = y.costTotal + static_cast<double>(y.costFixed) + y.lookaheadPenalty;
+    if (std::abs(xcost - ycost) < 1e-6) {
         return xcost > ycost;
     }
 
@@ -188,9 +188,9 @@ inline bool operator>(const HeuristicMapper::Node& x, const HeuristicMapper::Nod
         return true;
     }
 
-    auto xheur = x.costHeur + x.lookaheadPenalty;
-    auto yheur = y.costHeur + y.lookaheadPenalty;
-    if (xheur != yheur) {
+    const auto xheur = x.costHeur + x.lookaheadPenalty;
+    const auto yheur = y.costHeur + y.lookaheadPenalty;
+    if (std::abs(xheur - yheur) < 1e-6) {
         return xheur > yheur;
     } else {
         return x < y;

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -79,6 +79,7 @@ MappingResults map(const py::object& circ, Architecture& arch, Configuration& co
 PYBIND11_MODULE(pyqmap, m) {
     m.doc() = "pybind11 for the MQT QMAP quantum circuit mapping tool";
 
+    // Pre-defined architecture available within QMAP
     py::enum_<AvailableArchitecture>(m, "Arch")
             .value("IBM_QX4", AvailableArchitecture::IBM_QX4)
             .value("IBM_QX5", AvailableArchitecture::IBM_QX5)
@@ -89,52 +90,66 @@ PYBIND11_MODULE(pyqmap, m) {
             .value("Rigetti_Agave", AvailableArchitecture::Rigetti_Agave)
             .value("Rigetti_Aspen", AvailableArchitecture::Rigetti_Aspen)
             .export_values()
+            // allow construction from string
             .def(py::init([](const std::string& str) -> AvailableArchitecture { return architectureFromString(str); }));
 
+    // Mapping methodology to use
     py::enum_<Method>(m, "Method")
             .value("heuristic", Method::Heuristic)
             .value("exact", Method::Exact)
             .export_values()
+            // allow construction from string
             .def(py::init([](const std::string& str) -> Method { return methodFromString(str); }));
 
+    // Initial layout strategy
     py::enum_<InitialLayout>(m, "InitialLayout")
             .value("identity", InitialLayout::Identity)
             .value("static", InitialLayout::Static)
             .value("dynamic", InitialLayout::Dynamic)
             .export_values()
+            // allow construction from string
             .def(py::init([](const std::string& str) -> InitialLayout { return initialLayoutFromString(str); }));
 
+    // Gate clustering / layering strategy
     py::enum_<Layering>(m, "Layering")
             .value("individual_gates", Layering::IndividualGates)
             .value("disjoint_qubits", Layering::DisjointQubits)
             .value("odd_gates", Layering::OddGates)
             .value("qubit_triangle", Layering::QubitTriangle)
             .export_values()
+            // allow construction from string
             .def(py::init([](const std::string& str) -> Layering { return layeringFromString(str); }));
 
+    // Encoding settings for at-most-one and exactly-one constraints
     py::enum_<Encoding>(m, "Encoding")
             .value("naive", Encoding::Naive)
             .value("commander", Encoding::Commander)
             .value("bimander", Encoding::Bimander)
             .export_values()
+            // allow construction from string
             .def(py::init([](const std::string& str) -> Encoding { return encodingFromString(str); }));
 
+    // Grouping settings if using the commander encoding
     py::enum_<CommanderGrouping>(m, "CommanderGrouping")
             .value("fixed2", CommanderGrouping::Fixed2)
             .value("fixed3", CommanderGrouping::Fixed3)
             .value("halves", CommanderGrouping::Halves)
             .value("logarithm", CommanderGrouping::Logarithm)
             .export_values()
+            // allow construction from string
             .def(py::init([](const std::string& str) -> CommanderGrouping { return groupingFromString(str); }));
 
+    // Strategy for reducing the number of permutations/swaps considered in front of every gate
     py::enum_<SwapReduction>(m, "SwapReduction")
             .value("none", SwapReduction::None)
             .value("coupling_limit", SwapReduction::CouplingLimit)
             .value("custom", SwapReduction::Custom)
             .value("increasing", SwapReduction::Increasing)
             .export_values()
+            // allow construction from string
             .def(py::init([](const std::string& str) -> SwapReduction { return swapReductionFromString(str); }));
 
+    // All configuration options for QMAP
     py::class_<Configuration>(m, "Configuration", "Configuration options for the MQT QMAP quantum circuit mapping tool")
             .def(py::init<>())
             .def_readwrite("method", &Configuration::method)
@@ -165,6 +180,7 @@ PYBIND11_MODULE(pyqmap, m) {
             .def("json", &Configuration::json)
             .def("__repr__", &Configuration::toString);
 
+    // Results of the mapping process
     py::class_<MappingResults>(m, "MappingResults", "Results of the MQT QMAP quantum circuit mapping tool")
             .def(py::init<>())
             .def_readwrite("input", &MappingResults::input)
@@ -178,6 +194,7 @@ PYBIND11_MODULE(pyqmap, m) {
             .def("csv", &MappingResults::csv)
             .def("__repr__", &MappingResults::toString);
 
+    // Main class for storing circuit information
     py::class_<MappingResults::CircuitInfo>(m, "CircuitInfo", "Circuit information")
             .def(py::init<>())
             .def_readwrite("name", &MappingResults::CircuitInfo::name)
@@ -193,6 +210,7 @@ PYBIND11_MODULE(pyqmap, m) {
     auto arch       = py::class_<Architecture>(m, "Architecture", "Class representing device/backend information");
     auto properties = py::class_<Architecture::Properties>(arch, "Properties", "Class representing properties of an architecture");
 
+    // Properties of an architecture (e.g. number of qubits, connectivity, error rates, ...)
     properties.def(py::init<>())
             .def_property("name", &Architecture::Properties::getName, &Architecture::Properties::setName)
             .def_property("num_qubits", &Architecture::Properties::getNqubits, &Architecture::Properties::setNqubits)
@@ -225,6 +243,7 @@ PYBIND11_MODULE(pyqmap, m) {
             .def("__repr__", &Architecture::Properties::toString,
                  "Prints a JSON-formatted representation of all the information present in the :class:`.Properties`");
 
+    // Interface to the QMAP internal architecture class
     arch.def(py::init<>())
             .def(py::init<unsigned short, const CouplingMap&>(), "num_qubits"_a, "coupling_map"_a)
             .def(py::init<unsigned short, const CouplingMap&, const Architecture::Properties&>(), "num_qubits"_a, "coupling_map"_a, "properties"_a)
@@ -237,6 +256,7 @@ PYBIND11_MODULE(pyqmap, m) {
             .def("load_properties", py::overload_cast<const Architecture::Properties&>(&Architecture::loadProperties), "properties"_a)
             .def("load_properties", py::overload_cast<const std::string&>(&Architecture::loadProperties), "properties"_a);
 
+    // Main mapping function
     m.def("map", &map, "map a quantum circuit");
 #ifdef VERSION_INFO
     m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);


### PR DESCRIPTION
This PR updates the GitHub CodeQL configuration in anticipation of the deprecation of LGTM.
Most importantly, it adds further checks and a custom build step for C++ to also cover the Python bindings and the tests.
Finally, it also unifies and simplifies the whole configuration again.

By switching to the newer Ubuntu-22.04 runner, a recent enough Z3 version to build QMAP is available by default. This also allows the `codeql-action/init` action to properly build the Python package and (hopefully) provide better analysis.

The additional checks revealed a couple of tiny and easy to fix warnings/alerts that have subsequently been fixed.