### PR TITLE
⬆️  Update Z3 from version `4.8.17` to `4.11.2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           submodules: recursive
 
       - name: Installing boost and Z3
-        run: brew install boost z3@4.11.2
+        run: brew install boost z3
 
       - name: Configure CMake
         run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QMAP_TESTS=ON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: sudo apt-get install -y libboost-program-options-dev
 
       - name: Install Z3
-        run: python -m pip install z3-solver
+        run: python -m pip install z3-solver==4.11.2
 
       - name: Configure CMake
         run: |
@@ -91,7 +91,7 @@ jobs:
           submodules: recursive
 
       - name: Installing boost and Z3
-        run: brew install boost z3
+        run: brew install boost z3@4.11.2
 
       - name: Configure CMake
         run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QMAP_TESTS=ON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ defaults:
 env:
   BUILD_TYPE: Release
   CMAKE_BUILD_PARALLEL_LEVEL: 3
-  Z3_GIT_TAG: z3-4.8.17
+  Z3_GIT_TAG: z3-4.11.2
 
 jobs:
   codestyle:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,8 @@ on:
   workflow_dispatch:
 
 env:
-  Z3_GIT_TAG: z3-4.8.17
-  Z3_HASH: 2f59c37465aecdfbcc50a5ba0fe627535c0ff4cffb9080bfbddc0a2af0f97b53
+  Z3_GIT_TAG: z3-4.11.2
+  Z3_HASH: 721683d8c04b84f54408c44ee53de964d11ef33c10d92c36271a03189159fd4b
 
 jobs:
   build_manylinux_wheels:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       - name: Install Z3
-        run: brew install z3
+        run: brew install z3@4.11.2
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.9.0
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       - name: Install Z3
-        run: brew install z3@4.11.2
+        run: brew install z3
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.9.0
       - uses: actions/upload-artifact@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-verbosity = 3
 manylinux-x86_64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.linux]
-before-all = "/opt/python/cp39-cp39/bin/python -m pip install --upgrade pip && /opt/python/cp39-cp39/bin/python -m pip install z3-solver"
+before-all = "/opt/python/cp39-cp39/bin/python -m pip install --upgrade pip && /opt/python/cp39-cp39/bin/python -m pip install z3-solver==4.11.2"
 environment = { LD_LIBRARY_PATH = "$LD_LIBRARY_PATH:/opt/python/cp39-cp39/lib/python3.9/site-packages/z3/lib", Z3_ROOT = "/opt/python/cp39-cp39/lib/python3.9/site-packages/z3", Z3_DIR = "/opt/python/cp39-cp39/lib/python3.9/site-packages/z3", DEPLOY = "ON" }
 
 [tool.cibuildwheel.macos]


### PR DESCRIPTION
This PR updates Z3 to its latest version.
Furthermore it tries to pin the actual version of Z3 being used wherever possible. This should ensure better reproducibility across operating systems and the resulting Python packages.