### PR TITLE
🐍  Python Testing Setup

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: choco install z3 --version=4.11.2
       - if: runner.os == 'Windows'
         name: Set Z3 root
-        run: echo "{Z3_ROOT}={C:\ProgramData\chocolatey\lib\z3\tools}" >> $GITHUB_ENV
+        run: echo "Z3_ROOT=C:\ProgramData\chocolatey\lib\z3\tools" >> $GITHUB_ENV
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -7,6 +7,7 @@ on:
       - main
 
 env:
+  Z3_GIT_TAG: z3-4.11.2
   FORCE_COLOR: 3
 
 concurrency:
@@ -24,55 +25,74 @@ jobs:
       - name: Run mypy via nox
         run: nox -s mypy
 
-  tests:
-    runs-on: ${{ matrix.runs-on }}
-    needs: [lint]
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on: [ubuntu-22.04, macos-latest, windows-latest]
-    name: Tests on ${{ matrix.runs-on }}
+  python-tests-ubuntu:
+    runs-on: ubuntu-22.04
+    name: Python Tests Ubuntu
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Setup nox
         uses: excitedleigh/setup-nox@v2.1.0
-      - if: runner.os == 'macOS'
-        name: Install Z3 from brew
-        run: brew install z3
-      - if: runner.os == 'Windows'
-        name: Install Z3 from action
-        uses: pavpanchekha/setup-z3@master
-        with:
-          version: 4.11.2
-          distribution: win
-
-      # On Linux, all supported Python versions are tested.
-      # For the other systems, only the minimum and the maximum Python version are tested.
-
       - name: Test on 🐍 3.7
-        run: nox -s tests-3.7 --verbose
+        run: nox -s tests-3.7
       - name: Test on 🐍 3.8
-        if: runner.os == 'Linux'
         run: nox -s tests-3.8
       - name: Test on 🐍 3.9
-        if: runner.os == 'Linux'
         run: nox -s tests-3.9
-      - name: Test on 🐍 3.10
-        if: runner.os != 'Linux'
-        run: nox -s tests-3.10 --verbose
-
-  coverage:
-    runs-on: ubuntu-22.04
-    name: Test and Coverage on 🐍 3.10
-    steps:
-      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        name: Install Python
         with:
-          submodules: recursive
-      - name: Setup nox
-        uses: excitedleigh/setup-nox@v2.1.0
-      - name: Run coverage via nox
+          python-version: "3.10"
+      - name: Test and Coverage on 🐍 3.10
         run: nox -s coverage -- --cov-report=xml
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3
+
+  python-tests-macos:
+    runs-on: macos-latest
+    name: Python Tests macOS
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Install Z3 from brew
+        run: brew install z3
+      - name: Setup nox
+        uses: excitedleigh/setup-nox@v2.1.0
+      - name: Test on 🐍 3.7
+        run: nox -s tests-3.7
+      - name: Test on 🐍 3.10
+        run: nox -s tests-3.10
+
+  python-tests-windows:
+    runs-on: windows-latest
+    name: Python Tests Windows
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Cache Z3
+        id: cache-z3
+        uses: actions/cache@v3
+        with:
+          path: z3
+          key: python-${{ runner.OS }}-${{ env.Z3_GIT_TAG }}-${{ hashFiles('**/python-ci.yml') }}
+      - name: Building Z3
+        if: steps.cache-z3.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          git clone --branch $Z3_GIT_TAG --depth 1 https://github.com/Z3Prover/z3.git
+          cmake -S z3 -B z3/build -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 17 2022" -A x64 -DZ3_BUILD_LIBZ3_SHARED=FALSE -DZ3_BUILD_EXECUTABLE=False -DZ3_BUILD_TEST_EXECUTABLES=False
+          cmake --build z3/build --config Release --parallel 2
+      - name: Installing Z3
+        shell: bash
+        working-directory: ${{github.workspace}}/z3/build
+        run: cmake --build . --config Release --target INSTALL;
+      - name: Setup nox
+        uses: excitedleigh/setup-nox@v2.1.0
+      - name: Test on 🐍 3.7
+        run: nox -s tests-3.7
+      - name: Test on 🐍 3.10
+        run: nox -s tests-3.10

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -41,6 +41,11 @@ jobs:
       - if: runner.os == 'macOS'
         name: Install Z3 from brew
         run: brew install z3
+      - if: runner.os == 'Windows'
+        name: Install Z3 from chocolatey
+        uses: pavpanchekha/setup-z3@v1.2.2
+        with:
+          version: 4.11.2
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -42,11 +42,8 @@ jobs:
         name: Install Z3 from brew
         run: brew install z3
       - if: runner.os == 'Windows'
-        name: Install Z3 from action
-        uses: pavpanchekha/setup-z3@master
-        with:
-          version: 4.11.2
-          distribution: win
+        name: Install Z3 chocolatey
+        run: choco install z3 --version=4.11.2
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: brew install z3
       - if: runner.os == 'Windows'
         name: Install Z3 from chocolatey
-        uses: pavpanchekha/setup-z3@v1.2.2
+        uses: pavpanchekha/setup-z3@1.2.2
         with:
           version: 4.11.2
 

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -42,10 +42,11 @@ jobs:
         name: Install Z3 from brew
         run: brew install z3
       - if: runner.os == 'Windows'
-        name: Install Z3 from chocolatey
+        name: Install Z3 from action
         uses: pavpanchekha/setup-z3@1.2.2
         with:
           version: 4.11.2
+          distribution: win
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: [ubuntu-22.04, macos-latest, windows-latest]
     name: Tests on ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v3
@@ -38,6 +38,9 @@ jobs:
           submodules: recursive
       - name: Setup nox
         uses: excitedleigh/setup-nox@v2.1.0
+      - if: runner.os == 'macOS'
+        name: Install Z3 from brew
+        run: brew install z3
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.
@@ -55,7 +58,7 @@ jobs:
         run: nox -s tests-3.10
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Test and Coverage on 🐍 3.10
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup nox
         uses: excitedleigh/setup-nox@v2.1.0
       - name: Run mypy via nox
-        run:  nox -s mypy
+        run: nox -s mypy
 
   tests:
     runs-on: ${{ matrix.runs-on }}
@@ -64,6 +64,6 @@ jobs:
       - name: Setup nox
         uses: excitedleigh/setup-nox@v2.1.0
       - name: Run coverage via nox
-        run:  nox -s coverage -- --cov-report=xml
+        run: nox -s coverage -- --cov-report=xml
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -46,7 +46,9 @@ jobs:
         run: choco install z3 --version=4.11.2
       - if: runner.os == 'Windows'
         name: Set Z3 root
-        run: echo "Z3_ROOT=C:\ProgramData\chocolatey\lib\z3\tools" >> $env:GITHUB_ENV
+        run: |
+          echo "Z3_ROOT=C:\ProgramData\chocolatey\lib\z3\tools" >> $env:GITHUB_ENV
+          echo "Z3_DIR=C:\ProgramData\chocolatey\lib\z3\tools" >> $env:GITHUB_ENV
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: brew install z3
       - if: runner.os == 'Windows'
         name: Install Z3 from action
-        uses: pavpanchekha/setup-z3@1.2.2
+        uses: pavpanchekha/setup-z3@master
         with:
           version: 4.11.2
           distribution: win

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: choco install z3 --version=4.11.2
       - if: runner.os == 'Windows'
         name: Set Z3 root
-        run: echo "Z3_ROOT=C:\ProgramData\chocolatey\lib\z3\tools" >> $GITHUB_ENV
+        run: echo "Z3_ROOT=C:\ProgramData\chocolatey\lib\z3\tools" >> $env:GITHUB_ENV
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -42,19 +42,17 @@ jobs:
         name: Install Z3 from brew
         run: brew install z3
       - if: runner.os == 'Windows'
-        name: Install Z3 on Windows
-        run: python3 -m pip install z3-solver==4.11.2
-      - if: runner.os == 'Windows'
-        name: Set Z3 root
-        run: |
-          echo Z3_ROOT=$(python3 -c "import z3, os; print(os.path.dirname(z3.__file__))") >> $env:GITHUB_ENV
-          Add-Content $env:GITHUB_PATH "$(python3 -c "import z3, os; print(os.path.dirname(z3.__file__))")\lib"
+        name: Install Z3 from action
+        uses: pavpanchekha/setup-z3@master
+        with:
+          version: 4.11.2
+          distribution: win
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.
 
       - name: Test on 🐍 3.7
-        run: nox -s tests-3.7
+        run: nox -s tests-3.7 --verbose
       - name: Test on 🐍 3.8
         if: runner.os == 'Linux'
         run: nox -s tests-3.8
@@ -63,7 +61,7 @@ jobs:
         run: nox -s tests-3.9
       - name: Test on 🐍 3.10
         if: runner.os != 'Linux'
-        run: nox -s tests-3.10
+        run: nox -s tests-3.10 --verbose
 
   coverage:
     runs-on: ubuntu-22.04

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           echo "Z3_ROOT=C:\ProgramData\chocolatey\lib\z3\tools" >> $env:GITHUB_ENV
           echo "Z3_DIR=C:\ProgramData\chocolatey\lib\z3\tools" >> $env:GITHUB_ENV
+          Get-ChildItem -Path C:\ProgramData\chocolatey\lib\z3\tools -Recurse -ErrorAction SilentlyContinue -Force | %{$_.FullName}
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -46,10 +46,7 @@ jobs:
         run: choco install z3 --version=4.11.2
       - if: runner.os == 'Windows'
         name: Set Z3 root
-        run: |
-          echo "Z3_ROOT=C:\ProgramData\chocolatey\lib\z3\tools" >> $env:GITHUB_ENV
-          echo "Z3_DIR=C:\ProgramData\chocolatey\lib\z3\tools" >> $env:GITHUB_ENV
-          Get-ChildItem -Path C:\ProgramData\chocolatey\lib\z3\tools -Recurse -ErrorAction SilentlyContinue -Force | %{$_.FullName}
+        run: echo "Z3_ROOT=C:\ProgramData\chocolatey\lib\z3\tools\bin" >> $env:GITHUB_ENV
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,69 @@
+name: Python-CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  FORCE_COLOR: 3
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Run my[py] linter
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup nox
+        uses: excitedleigh/setup-nox@v2.1.0
+      - name: Run mypy via nox
+        run:  nox -s mypy
+
+  tests:
+    runs-on: ${{ matrix.runs-on }}
+    needs: [lint]
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+    name: Tests on ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Setup nox
+        uses: excitedleigh/setup-nox@v2.1.0
+
+      # On Linux, all supported Python versions are tested.
+      # For the other systems, only the minimum and the maximum Python version are tested.
+
+      - name: Test on 🐍 3.7
+        run: nox -s tests-3.7
+      - name: Test on 🐍 3.8
+        if: runner.os == 'Linux'
+        run: nox -s tests-3.8
+      - name: Test on 🐍 3.9
+        if: runner.os == 'Linux'
+        run: nox -s tests-3.9
+      - name: Test on 🐍 3.10
+        if: runner.os != 'Linux'
+        run: nox -s tests-3.10
+
+  coverage:
+    runs-on: ubuntu-latest
+    name: Test and Coverage on 🐍 3.10
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Setup nox
+        uses: excitedleigh/setup-nox@v2.1.0
+      - name: Run coverage via nox
+        run:  nox -s coverage -- --cov-report=xml
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -48,7 +48,7 @@ jobs:
         name: Set Z3 root
         run: |
           echo Z3_ROOT=$(python3 -c "import z3, os; print(os.path.dirname(z3.__file__))") >> $env:GITHUB_ENV
-          Get-ChildItem -Path $(python3 -c "import z3, os; print(os.path.dirname(z3.__file__))") -Recurse -ErrorAction SilentlyContinue -Force | %{$_.FullName}
+          Add-Content $env:GITHUB_PATH "$(python3 -c "import z3, os; print(os.path.dirname(z3.__file__))")\lib"
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -42,11 +42,13 @@ jobs:
         name: Install Z3 from brew
         run: brew install z3
       - if: runner.os == 'Windows'
-        name: Install Z3 chocolatey
-        run: python3 -m pip install -U pip z3-solver==4.11.2
+        name: Install Z3 on Windows
+        run: python3 -m pip install z3-solver==4.11.2
       - if: runner.os == 'Windows'
         name: Set Z3 root
-        run: echo ("Z3_ROOT=" + $(python3 -c "import z3, os; print(os.path.dirname(z3.__file__))")) >> $env:GITHUB_ENV
+        run: |
+          echo Z3_ROOT=$(python3 -c "import z3, os; print(os.path.dirname(z3.__file__))") >> $env:GITHUB_ENV
+          Get-ChildItem -Path $env:Z3_ROOT -Recurse -ErrorAction SilentlyContinue -Force | %{$_.FullName}
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -44,6 +44,9 @@ jobs:
       - if: runner.os == 'Windows'
         name: Install Z3 chocolatey
         run: choco install z3 --version=4.11.2
+      - if: runner.os == 'Windows'
+        name: Set Z3 root
+        run: echo "{Z3_ROOT}={C:\ProgramData\chocolatey\lib\z3\tools}" >> $GITHUB_ENV
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -48,7 +48,7 @@ jobs:
         name: Set Z3 root
         run: |
           echo Z3_ROOT=$(python3 -c "import z3, os; print(os.path.dirname(z3.__file__))") >> $env:GITHUB_ENV
-          Get-ChildItem -Path $env:Z3_ROOT -Recurse -ErrorAction SilentlyContinue -Force | %{$_.FullName}
+          Get-ChildItem -Path $(python3 -c "import z3, os; print(os.path.dirname(z3.__file__))") -Recurse -ErrorAction SilentlyContinue -Force | %{$_.FullName}
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -43,10 +43,10 @@ jobs:
         run: brew install z3
       - if: runner.os == 'Windows'
         name: Install Z3 chocolatey
-        run: choco install z3 --version=4.11.2
+        run: python3 -m pip install -U pip z3-solver==4.11.2
       - if: runner.os == 'Windows'
         name: Set Z3 root
-        run: echo "Z3_ROOT=C:\ProgramData\chocolatey\lib\z3\tools\bin" >> $env:GITHUB_ENV
+        run: echo ("Z3_ROOT=" + python3 -c "import z3, os; print(os.path.dirname(z3.__file__))") >> $env:GITHUB_ENV
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: python3 -m pip install -U pip z3-solver==4.11.2
       - if: runner.os == 'Windows'
         name: Set Z3 root
-        run: echo ("Z3_ROOT=" + python3 -c "import z3, os; print(os.path.dirname(z3.__file__))") >> $env:GITHUB_ENV
+        run: echo ("Z3_ROOT=" + $(python3 -c "import z3, os; print(os.path.dirname(z3.__file__))")) >> $env:GITHUB_ENV
 
       # On Linux, all supported Python versions are tested.
       # For the other systems, only the minimum and the maximum Python version are tested.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ check_submodule_present(LogicBlocks)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # search for Z3
-find_package(Z3)
+find_package(Z3 REQUIRED)
 if(Z3_FOUND AND NOT TARGET z3::z3lib)
   message(STATUS "Found Z3 with version ${Z3_VERSION_STRING}")
   add_library(z3::z3lib IMPORTED INTERFACE)

--- a/cmake/FindZ3.cmake
+++ b/cmake/FindZ3.cmake
@@ -40,6 +40,10 @@ if(DEFINED ENV{Z3_ROOT})
   set(Z3_ROOT $ENV{Z3_ROOT})
   message("Z3_ROOT: ${Z3_ROOT}")
 endif()
+if(DEFINED ENV{Z3_DIR})
+  set(Z3_DIR $ENV{Z3_DIR})
+  message("Z3_DIR: ${Z3_DIR}")
+endif()
 if(NOT ${Z3_ROOT} STREQUAL "")
   find_path(
     Z3_CXX_INCLUDE_DIRS

--- a/cmake/FindZ3.cmake
+++ b/cmake/FindZ3.cmake
@@ -40,10 +40,6 @@ if(DEFINED ENV{Z3_ROOT})
   set(Z3_ROOT $ENV{Z3_ROOT})
   message("Z3_ROOT: ${Z3_ROOT}")
 endif()
-if(DEFINED ENV{Z3_DIR})
-  set(Z3_DIR $ENV{Z3_DIR})
-  message("Z3_DIR: ${Z3_DIR}")
-endif()
 if(NOT ${Z3_ROOT} STREQUAL "")
   find_path(
     Z3_CXX_INCLUDE_DIRS

--- a/mqt/qmap/compile.py
+++ b/mqt/qmap/compile.py
@@ -75,7 +75,7 @@ def compile(
 ) -> Tuple[QuantumCircuit, MappingResults]:
     """Interface to the MQT QMAP tool for mapping quantum circuits
 
-    :param circ: Qiskit QuantumCircuit object, path to circuit file, or path to Qiskit QuantumCircuit pickle
+    :param circ: Qiskit QuantumCircuit object or path to circuit file
     :type circ: Union[QuantumCircuit, str]
     :param arch: Architecture to map to. Either a path to a file with architecture information, one of the available architectures (Arch), qmap.Architecture, or `qiskit.providers.backend` (if Qiskit is installed)
     :type arch: Optional[Union[str, Arch, Architecture, Backend]]
@@ -120,10 +120,6 @@ def compile(
 
     if subgraph is None:
         subgraph = set()
-
-    if isinstance(circ, str) and Path(circ).suffix == ".pickle":
-        with open(circ, "rb") as f:
-            circ = pickle.load(f)
 
     architecture = Architecture()
     if arch is None and calibration is None:

--- a/mqt/qmap/compile.py
+++ b/mqt/qmap/compile.py
@@ -43,9 +43,9 @@ def extract_initial_layout_from_qasm(qasm: str, qregs: List[QuantumRegister]) ->
             # split line into tokens
             tokens = line.split(" ")
             # convert tokens to integers
-            tokens = [int(token) for token in tokens]
+            int_tokens = [int(token) for token in tokens]
             # create an empty layout
-            layout = Layout().from_intlist(tokens, *qregs)
+            layout = Layout().from_intlist(int_tokens, *qregs)
             return layout
     raise ValueError("No initial layout found in QASM file.")
 

--- a/mqt/qmap/compile.py
+++ b/mqt/qmap/compile.py
@@ -2,8 +2,6 @@
 # This file is part of MQT QMAP library which is released under the MIT license.
 # See file README.md or go to http://iic.jku.at/eda/research/quantum_verification/ for more information.
 #
-import pickle
-from pathlib import Path
 from typing import List, Optional, Set, Tuple, Union
 
 from mqt.qmap.pyqmap import (

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,6 +17,7 @@ if os.environ.get("CI", None):
 def tests(session: Session) -> None:
     """Run the test suite."""
     session.install("-e", ".[test]")
+    session.install("z3-solver")
     session.run("pytest", *session.posargs)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,6 +21,13 @@ def tests(session: Session) -> None:
 
 
 @nox.session
+def coverage(session: Session) -> None:
+    """Run the test suite and generate a coverage report."""
+    session.install("-e", ".[test,coverage]")
+    session.run("pytest", "--cov", *session.posargs)
+
+
+@nox.session
 def lint(session: Session) -> None:
     """Lint the Python part of the codebase."""
     session.install("pre-commit")
@@ -34,6 +41,14 @@ def pylint(session: Session) -> None:
     session.install("pylint")
     session.install("-e", ".")
     session.run("pylint", "mqt.qmap", "--extension-pkg-allow-list=mqt.qmap.pyqmap", *session.posargs)
+
+
+@nox.session
+def mypy(session: Session) -> None:
+    """Run mypy."""
+
+    session.install("pre-commit")
+    session.run("pre-commit", "run", "--all-files", "--hook-stage", "manual", "mypy", *session.posargs)
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,6 @@ if os.environ.get("CI", None):
 def tests(session: Session) -> None:
     """Run the test suite."""
     session.install("-e", ".[test]")
-    session.install("z3-solver")
     session.run("pytest", *session.posargs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ archs = "auto64"
 skip = "*-musllinux*"
 test-skip = "cp311-* *-macosx_arm64 *-musllinux* *aarch64"
 test-extras = ["test"]
-test-command = "python -m pytest {project}/test/python"
+test-command = "python -c \"from mqt import qmap\""
 environment = { DEPLOY = "ON" }
 build-frontend = "build"
 build-verbosity = 3

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ setup(
     install_requires=["qiskit-terra>=0.20.2,<0.22.0"],
     extras_require={
         "test": ["pytest~=7.1.1", "mqt.qcec~=2.0.0rc7"],
+        "coverage": ["coverage[toml]~=6.4.2", "pytest-cov~=3.0.0"],
         "docs": [
             "sphinx>=5.1.1",
             "sphinx-rtd-theme",
@@ -121,7 +122,7 @@ setup(
             "pybtex>=0.24",
             "importlib_metadata>=3.6; python_version < '3.10'",
         ],
-        "dev": ["mqt.qmap[test, docs]"],  # requires Pip 21.2 or newer
+        "dev": ["mqt.qmap[test, coverage, docs]"],  # requires Pip 21.2 or newer
     },
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -116,27 +116,33 @@ void Architecture::loadProperties(std::istream&& is) {
         std::stringstream        ss(line);
         std::vector<std::string> data{};
         parse_line(line, ',', {'\"'}, {'\\'}, data);
-        properties.t1Time.set(qubitNumber, std::stod(data[1]));
-        properties.t2Time.set(qubitNumber, std::stod(data[2]));
-        properties.qubitFrequency.set(qubitNumber, std::stod(data[3]));
-        properties.readoutErrorRate.set(qubitNumber, std::stod(data[4]));
+        properties.t1Time.set(qubitNumber, std::stod(data.at(1)));
+        properties.t2Time.set(qubitNumber, std::stod(data.at(2)));
+        properties.qubitFrequency.set(qubitNumber, std::stod(data.at(3)));
+        properties.readoutErrorRate.set(qubitNumber, std::stod(data.at(4)));
         // csv file reports average single qubit fidelities
         for (const auto& operation: SingleQubitGates) {
-            properties.setSingleQubitErrorRate(qubitNumber, operation, std::stod(data[5]));
+            properties.setSingleQubitErrorRate(qubitNumber, operation, std::stod(data.at(5)));
         }
-        std::string s = data[6];
-        while (std::regex_search(s, sMatch, regexDoubleFidelity)) {
-            auto a = static_cast<unsigned short>(std::stoul(sMatch.str(2U)));
-            auto b = static_cast<unsigned short>(std::stoul(sMatch.str(3U)));
-            if (!isArchitectureAvailable()) {
-                couplingMap.emplace(a, b);
+        // only try to parse CNOT fidelities if there are any
+        if (data.size() >= 7U) {
+            std::string s = data[6];
+            while (std::regex_search(s, sMatch, regexDoubleFidelity)) {
+                auto a = static_cast<unsigned short>(std::stoul(sMatch.str(2U)));
+                auto b = static_cast<unsigned short>(std::stoul(sMatch.str(3U)));
+                if (!isArchitectureAvailable()) {
+                    couplingMap.emplace(a, b);
+                }
+                // calc moving average
+                averageCNOTFidelity = averageCNOTFidelity + (std::stod(sMatch.str(4U)) - averageCNOTFidelity) / ++numCNOTFidelities;
+                properties.setTwoQubitErrorRate(a, b, std::stod(sMatch.str(4U)));
+                s = sMatch.suffix().str();
             }
-            averageCNOTFidelity = averageCNOTFidelity + (std::stod(sMatch.str(4U)) - averageCNOTFidelity) / ++numCNOTFidelities; //calc moving average
-            properties.setTwoQubitErrorRate(a, b, std::stod(sMatch.str(4U)));
-            s = sMatch.suffix().str();
         }
-        properties.calibrationDate.set(qubitNumber, data[7]);
-        qubitNumber++;
+        if (data.size() == 8U) {
+            properties.calibrationDate.set(qubitNumber, data[7]);
+        }
+        ++qubitNumber;
     }
 
     if (isArchitectureAvailable()) {

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -107,7 +107,7 @@ void Architecture::loadProperties(std::istream&& is) {
     std::string line;
     std::string word;
     std::regex  regexDoubleFidelity =
-            std::regex(R"(((\d+).?(\d+):\W*?(\d+\.\d+e?-?\d+)))");
+            std::regex(R"(((\d+).?(\d+):\W*?(-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?)))");
     std::smatch sMatch;
     std::getline(is, line); //skip first line
     // load edges

--- a/test/python/test_compile.py
+++ b/test/python/test_compile.py
@@ -1,0 +1,107 @@
+import pytest
+from mqt import qcec, qmap
+
+from qiskit import QuantumCircuit
+
+
+@pytest.fixture
+def example_circuit() -> QuantumCircuit:
+    qc = QuantumCircuit(3)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.cx(1, 2)
+    qc.measure_all()
+    return qc
+
+
+def test_either_arch_or_calibration(example_circuit: QuantumCircuit) -> None:
+    """Test that either arch or calibration must be provided."""
+    with pytest.raises(ValueError):
+        qmap.compile(example_circuit, arch=None, calibration=None)
+
+
+@pytest.mark.parametrize(
+    "arch",
+    [
+        "IBM_QX4",
+        "IBM_QX5",
+        "IBMQ_Yorktown",
+        "IBMQ_London",
+        "IBMQ_Bogota",
+        "IBMQ_Tokyo",
+        "Rigetti_Agave",
+        "Rigetti_Aspen",
+    ],
+)
+def test_available_architectures_str(example_circuit: QuantumCircuit, arch: str) -> None:
+    """Test that the available architectures can be properly used."""
+    example_circuit_mapped, results = qmap.compile(example_circuit, arch=arch)
+    assert results.timeout is False
+    assert results.mapped_circuit != ""
+
+    result = qcec.verify(example_circuit, example_circuit_mapped)
+    assert result.considered_equivalent() is True
+
+
+# test that all available architecture enumerations can be properly used
+@pytest.mark.parametrize(
+    "arch",
+    [
+        qmap.Arch.IBM_QX4,
+        qmap.Arch.IBM_QX5,
+        qmap.Arch.IBMQ_Yorktown,
+        qmap.Arch.IBMQ_London,
+        qmap.Arch.IBMQ_Bogota,
+        qmap.Arch.IBMQ_Tokyo,
+        qmap.Arch.Rigetti_Agave,
+        qmap.Arch.Rigetti_Aspen,
+    ],
+)
+def test_available_architectures_enum(example_circuit: QuantumCircuit, arch: qmap.Arch) -> None:
+    """Test that the available architecture enums can be properly used."""
+    example_circuit_mapped, results = qmap.compile(example_circuit, arch=arch)
+    assert results.timeout is False
+    assert results.mapped_circuit != ""
+
+    result = qcec.verify(example_circuit, example_circuit_mapped)
+    assert result.considered_equivalent() is True
+
+
+def test_architecture_from_file(example_circuit: QuantumCircuit) -> None:
+    """Test that architectures from files can be properly used."""
+    with open("test_architecture.arch", "w+") as f:
+        f.write("3\n0 1\n0 2\n1 2\n")
+
+    example_circuit_mapped, results = qmap.compile(example_circuit, arch="test_architecture.arch")
+    assert results.timeout is False
+    assert results.mapped_circuit != ""
+
+    result = qcec.verify(example_circuit, example_circuit_mapped)
+    assert result.considered_equivalent() is True
+
+
+def test_architecture_from_python(example_circuit: QuantumCircuit) -> None:
+    """Test that architectures from python can be properly used."""
+    arch = qmap.Architecture(3, {(0, 1), (0, 2), (1, 2)})
+    example_circuit_mapped, results = qmap.compile(example_circuit, arch=arch)
+    assert results.timeout is False
+    assert results.mapped_circuit != ""
+
+    result = qcec.verify(example_circuit, example_circuit_mapped)
+    assert result.considered_equivalent() is True
+
+
+def test_calibration_from_file(example_circuit: QuantumCircuit) -> None:
+    """Test that calibrations from files can be properly used."""
+    with open("test_calibration.cal", "w+") as f:
+        f.write("Header\n")
+        f.write('Q0,0,0,0,1e-2,1e-4,"0_1: 1e-2, 0_2: 1e-2"\n')
+        f.write('Q1,0,0,0,1e-2,1e-4,"1_2: 1e-2"\n')
+        f.write("Q2,0,0,0,1e-2,1e-4," "\n")
+
+    example_circuit_mapped, results = qmap.compile(example_circuit, arch=None, calibration="test_calibration.cal")
+    assert results.timeout is False
+    assert results.mapped_circuit != ""
+
+    result = qcec.verify(example_circuit, example_circuit_mapped)
+    assert result.considered_equivalent() is True

--- a/test/python/test_exact_mapper.py
+++ b/test/python/test_exact_mapper.py
@@ -4,7 +4,7 @@ from qiskit import QuantumCircuit
 from qiskit.providers.fake_provider import FakeLondon
 
 
-def test_exact_no_swaps_trivial_layout():
+def test_exact_no_swaps_trivial_layout() -> None:
     """Verify that the exact mapper works on a simple circuit that requires no swaps on a trivial initial layout."""
     qc = QuantumCircuit(3)
     qc.h(0)
@@ -21,7 +21,7 @@ def test_exact_no_swaps_trivial_layout():
     assert result.considered_equivalent() is True
 
 
-def test_exact_no_swaps_non_trivial_layout():
+def test_exact_no_swaps_non_trivial_layout() -> None:
     """Verify that the exact mapper works on a simple circuit that requires a non-trivial layout to achieve no swaps."""
     qc = QuantumCircuit(4)
     qc.h(0)
@@ -40,7 +40,7 @@ def test_exact_no_swaps_non_trivial_layout():
     assert result.considered_equivalent() is True
 
 
-def test_exact_non_trivial_swaps():
+def test_exact_non_trivial_swaps() -> None:
     """Verify that the exact mapper works on a simple circuit that requires at least a single SWAP."""
     qc = QuantumCircuit(3)
     qc.h(0)

--- a/test/python/test_heuristic_mapper.py
+++ b/test/python/test_heuristic_mapper.py
@@ -4,7 +4,7 @@ from qiskit import QuantumCircuit
 from qiskit.providers.fake_provider import FakeLondon
 
 
-def test_heuristic_no_swaps_trivial_layout():
+def test_heuristic_no_swaps_trivial_layout() -> None:
     """Verify that the heuristic mapper works on a simple circuit that requires no swaps on a trivial initial layout."""
     qc = QuantumCircuit(3)
     qc.h(0)
@@ -21,7 +21,7 @@ def test_heuristic_no_swaps_trivial_layout():
     assert result.considered_equivalent() is True
 
 
-def test_heuristic_no_swaps_non_trivial_layout():
+def test_heuristic_no_swaps_non_trivial_layout() -> None:
     """Verify that the heuristic mapper works on a simple circuit that requires a non-trivial layout to achieve no swaps."""
     qc = QuantumCircuit(4)
     qc.h(0)
@@ -40,7 +40,7 @@ def test_heuristic_no_swaps_non_trivial_layout():
     assert result.considered_equivalent() is True
 
 
-def test_heuristic_non_trivial_swaps():
+def test_heuristic_non_trivial_swaps() -> None:
     """Verify that the heuristic mapper works on a simple circuit that requires at least a single SWAP."""
     qc = QuantumCircuit(3)
     qc.h(0)

--- a/test/python/test_qiskit_backend_imports.py
+++ b/test/python/test_qiskit_backend_imports.py
@@ -20,42 +20,42 @@ def example_circuit() -> QuantumCircuit:
     return qc
 
 
-def test_old_backend_v1(example_circuit: QuantumCircuit):
+def test_old_backend_v1(example_circuit: QuantumCircuit) -> None:
     """Test that circuits can be mapped to Qiskit BackendV1 instances providing the old basis_gates."""
     _, results = qmap.compile(example_circuit, arch=FakeLondon())
     assert results.timeout is False
     assert results.mapped_circuit != ""
 
 
-def test_old_backend_v2(example_circuit: QuantumCircuit):
+def test_old_backend_v2(example_circuit: QuantumCircuit) -> None:
     """Test that circuits can be mapped to Qiskit BackendV2 instances providing the old basis_gates."""
     _, results = qmap.compile(example_circuit, arch=FakeLondonV2())
     assert results.timeout is False
     assert results.mapped_circuit != ""
 
 
-def test_new_backend_v1(example_circuit: QuantumCircuit):
+def test_new_backend_v1(example_circuit: QuantumCircuit) -> None:
     """Test that circuits can be mapped to Qiskit BackendV1 instances providing the new basis_gates."""
     _, results = qmap.compile(example_circuit, arch=FakeAthens())
     assert results.timeout is False
     assert results.mapped_circuit != ""
 
 
-def test_new_backend_v2(example_circuit: QuantumCircuit):
+def test_new_backend_v2(example_circuit: QuantumCircuit) -> None:
     """Test that circuits can be mapped to Qiskit BackendV2 instances providing the new basis_gates."""
     _, results = qmap.compile(example_circuit, arch=FakeAthensV2())
     assert results.timeout is False
     assert results.mapped_circuit != ""
 
 
-def test_architecture_from_v1_backend_properties(example_circuit: QuantumCircuit):
+def test_architecture_from_v1_backend_properties(example_circuit: QuantumCircuit) -> None:
     """Test that circuits can be mapped by simply providing the backend properties (the BackendV1 way)."""
     _, results = qmap.compile(example_circuit, arch=None, calibration=FakeLondon().properties())
     assert results.timeout is False
     assert results.mapped_circuit != ""
 
 
-def test_architecture_from_v2_target(example_circuit: QuantumCircuit):
+def test_architecture_from_v2_target(example_circuit: QuantumCircuit) -> None:
     """Test that circuits can be mapped by simply providing the target (the BackendV2 way)."""
     _, results = qmap.compile(example_circuit, arch=None, calibration=FakeLondonV2().target)
     assert results.timeout is False


### PR DESCRIPTION
Currently, Python testing is handled as part of the wheel building process. Every wheel is tested across with all available tests. 
This significantly contributes to the time spent building wheels and is much better left as an individual task.

This PR adds a proper Python testing setup to the CI of the project. To this end, it adds `nox` sessions for determining coverage
```bash 
nox -rs coverage
```
and running the mypy linter
```bash
nox -rs mypy
```
Both of these steps, in combination with the regular tests (`nox -rs tests`), are included in a new CI workflow.
This flow first checks the code base with the mypy linter and then starts running the tests under all supported operating systems and a suitable combination of Python versions. Furthermore, a separate job determines the coverage and publishes it to codecov.

In the process of writing tests to increase the coverage, a small bug in the parser for the calibration data from files was found and subsequently fixed. Yay tests 🥳 
Finally, all warnings reported by `mypy` have been addressed.