### PR TITLE
🔧 Codecov Config Update

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -20,3 +20,7 @@ parsers:
     branch_detection:
       conditional: no
       loop: no
+
+codecov:
+  notify:
+    after_n_builds: 2


### PR DESCRIPTION
Per default, codecov reports the coverage status on a PR once the first report is uploaded. However, if there is more than one job tracking coverage (C++ and Python, for example), then this incorrectly reports a lowered coverage until both reports have been received.

Conveniently, codecov offers an option to delay the notification so that it only posts the notification after both reports have been received. 