### PR TITLE
🐛 temporary workaround for retworkx failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
     packages=find_namespace_packages(include=["mqt.*"]),
-    install_requires=["qiskit-terra>=0.20.2,<0.22.0"],
+    install_requires=["qiskit-terra>=0.20.2,<0.22.0", "retworkx>=0.11.0,<0.12.0"],
     extras_require={
         "test": ["pytest~=7.1.1", "mqt.qcec~=2.0.0rc7"],
         "coverage": ["coverage[toml]>=6.4.2,<6.6.0", "pytest-cov>=3.0,<4.1"],


### PR DESCRIPTION
The recent update of `retworkx` to version `0.12.0` broke something inside of the Qiskit circuit drawer leading to test failures under Python 3.10. At the moment, there is no tracking issue for that bug and I don't have the time to create one.

This is a temporary workaround that pins `retworkx` to a version less than `0.12.0`.