### PR TITLE
👷🔧 Update codecov config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,5 +85,8 @@ jobs:
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.1
         with:
+          fail_ci_if_error: true
+          flags: cpp
           gcov: true
           gcov_ignore: "extern/**/*"
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -69,3 +69,7 @@ jobs:
       - if: runner.os == 'Linux'
         name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3.1.1
+        with:
+          fail_ci_if_error: true
+          flags: python
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov has been really flaky over the past couple of months with uploads sporadically failing and runs showing up as failed on the Codecov website although passing on GitHub. This PR updates the codecov configuration of the project.
First of all, an upload token is used which should ensure that uploading succeeds in most cases.
Secondly, the action now fails whenever an error occurred in the process.
Lastly, the two coverage jobs are assigned flags which allows to separate the individual coverages a little more.