### PR TITLE
🔧 Update GitHub to PyPI publish action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,9 +83,8 @@ jobs:
         with:
           name: artifact
           path: dist
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.pypi_password }}
           skip_existing: true
           verbose: true


### PR DESCRIPTION
## Description

The `master` branch of the `gh-action-pypi-publish` action has been deprecated in July.
This tiny PR updates the action to the recommended usage from https://github.com/pypa/gh-action-pypi-publish.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
