### PR TITLE
🐛🔧 Fix and Enhance Codecov Config

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,8 +1,8 @@
 ignore:
   - "extern/**/*"
   - "apps/*"
-  - "test/*.cpp"
-  - "mqt/**/*"
+  - "test/**/*.cpp"
+  - "mqt/**/*.cpp"
 
 coverage:
   range: 60..90

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,12 +8,30 @@ coverage:
   range: 60..90
   precision: 1
   status:
-    project:
-      default:
-        threshold: 0.5%
-    patch:
-      default:
-        threshold: 1%
+    project: off
+    patch: off
+
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: cpp
+      paths:
+        - "include/**/*.hpp"
+        - "src/**/*.cpp"
+      statuses:
+        - type: project
+          threshold: 0.5%
+        - type: patch
+          threshold: 1%
+    - name: python
+      paths:
+        - "mqt/**/*.py"
+      statuses:
+        - type: project
+          threshold: 0.5%
+        - type: patch
+          threshold: 1%
 
 parsers:
   gcov:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,7 +1,7 @@
 ignore:
   - "extern/**/*"
   - "apps/*"
-  - "test/**/*.cpp"
+  - "test/**/*"
   - "mqt/**/*.cpp"
 
 coverage:


### PR DESCRIPTION
## Description

Up until today it has been a mystery why the coverage report for python was reported as empty on codecov although it was not empty when inspected. No more mystery... turns out codecov was configured to ignore all files under `mqt/**/*`... which effectively turns all coverage reports empty. 

This PR fixes the underlying issue.
In addition, it uses the newly introduced *flag* feature of codecov to split the coverage between the languages.
In the future, different thresholds could be applied to C++ and Python.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
