### PR TITLE
🔧 Fixup codecov flag config

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -29,6 +29,7 @@ flag_management:
       paths:
         - "mqt/**/*.py"
       statuses:
+        - type: project
         - type: patch
           target: 95%
 

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -13,25 +13,24 @@ coverage:
 
 flag_management:
   default_rules:
-    carryforward: true
+    statuses:
+      - type: project
+        target: auto
+        threshold: 0.5%
+      - type: patch
+        target: 90%
+        threshold: 1%
   individual_flags:
     - name: cpp
       paths:
-        - "include/**/*.hpp"
-        - "src/**/*.cpp"
-      statuses:
-        - type: project
-          threshold: 0.5%
-        - type: patch
-          threshold: 1%
+        - "include"
+        - "src"
     - name: python
       paths:
         - "mqt/**/*.py"
       statuses:
-        - type: project
-          threshold: 0.5%
         - type: patch
-          threshold: 1%
+          target: 95%
 
 parsers:
   gcov:


### PR DESCRIPTION
## Description

It turns out that #154 did not properly configure the coverage flags as some header and source files got lost.
This PR tries to fix that and also unifies some of the configuration settings.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass. (C++ coverage is only lower due to the correct configuration)
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
