### PR TITLE
Fix compile issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.24)
+cmake_minimum_required(VERSION 3.19...3.24)
 
 project(
   qmap

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ circ_mapped, results = qmap.compile(circ, arch=FakeLondon())
 
 ## System Requirements and Building
 
-The implementation is compatible with any C++17 compiler and a minimum CMake version of 3.18.
+The implementation is compatible with any C++17 compiler and a minimum CMake version of 3.19.
 Please refer to the [documentation](https://mqtqmap.readthedocs.io/en/latest/) on how to build the project.
 
 Building (and running) is continuously tested under Linux, macOS, and Windows using the [latest available system versions for GitHub Actions](https://github.com/actions/virtual-environments).

--- a/cmake/FindZ3.cmake
+++ b/cmake/FindZ3.cmake
@@ -119,7 +119,7 @@ if(NOT FOUND_SUITABLE_VERSION)
     execute_process(
       COMMAND ${Python_EXECUTABLE} -c "import os, z3; print(os.path.dirname(z3.__file__))"
       OUTPUT_VARIABLE Z3_PYTHON_ROOT)
-    string(STRIP ${Z3_PYTHON_ROOT} Z3_PYTHON_ROOT)
+    string(STRIP "${Z3_PYTHON_ROOT}" Z3_PYTHON_ROOT)
     message(STATUS "Z3_PYTHON_ROOT: ${Z3_PYTHON_ROOT}")
 
     if(Z3_PYTHON_ROOT)

--- a/docs/source/DevelopmentGuide.rst
+++ b/docs/source/DevelopmentGuide.rst
@@ -94,7 +94,7 @@ Initial Setup
 Working on the core C++ library
 ###############################
 
-Building the project requires a C++ compiler supporting *C++17* and CMake with a minimum version of *3.18*.
+Building the project requires a C++ compiler supporting *C++17* and CMake with a minimum version of *3.19*.
 
     .. note::
         We noticed some issues when compiling with Microsoft's *MSCV* compiler toolchain.

--- a/docs/source/Installation.rst
+++ b/docs/source/Installation.rst
@@ -104,7 +104,7 @@ In order to get the best performance out of QMAP and enable platform-specific co
 
         (venv) $ pip install mqt.qmap --no-binary mqt.qmap
 
-This requires a `C++ compiler <https://en.wikipedia.org/wiki/List_of_compilers#C++_compilers>`_ compiler supporting *C++17*, a minimum `CMake <https://cmake.org/>`_ version of *3.18* and the `SMT solver Z3 <https://github.com/Z3Prover/z3>`_. Z3 has to be installed and the dynamic linker has to be able to find the library. This can be accomplished in a multitude of ways:
+This requires a `C++ compiler <https://en.wikipedia.org/wiki/List_of_compilers#C++_compilers>`_ compiler supporting *C++17*, a minimum `CMake <https://cmake.org/>`_ version of *3.19* and the `SMT solver Z3 <https://github.com/Z3Prover/z3>`_. Z3 has to be installed and the dynamic linker has to be able to find the library. This can be accomplished in a multitude of ways:
 
 - Under Ubuntu 20.04 and newer: :code:`sudo apt-get install libz3-dev`
 - Under macOS: :code:`brew install z3`

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -41,7 +41,7 @@ void Architecture::loadCouplingMap(std::istream&& is) {
 
     // get number of qubits
     if (std::getline(is, line)) {
-        if (std::regex_match(line, m, r_nqubits)) {
+        if (std::regex_search(line, m, r_nqubits)) {
             nqubits = static_cast<unsigned short>(std::stoul(m.str(1)));
         } else {
             throw QMAPException("No qubit count found in coupling map file: " + line);
@@ -51,7 +51,7 @@ void Architecture::loadCouplingMap(std::istream&& is) {
     }
     // load edges
     while (std::getline(is, line)) {
-        if (std::regex_match(line, m, r_edge)) {
+        if (std::regex_search(line, m, r_edge)) {
             auto v1 = static_cast<unsigned short>(std::stoul(m.str(1)));
             auto v2 = static_cast<unsigned short>(std::stoul(m.str(2)));
             couplingMap.emplace(v1, v2);


### PR DESCRIPTION
## Description

- Bumped the minimum required version of CMAKE to 3.19 (to enable the use of `find_package_check_version`)
- Fixed issue in CMAKE when z3 python root path is empty
- replaced `std::regex_match` with `std::regex_search` in the loading of coupling maps for a more lenient handling of white spaces in coupling map files