### PR TITLE
🐛 Fix Qiskit compatibility

### DIFF
--- a/mqt/qmap/compile.py
+++ b/mqt/qmap/compile.py
@@ -179,6 +179,14 @@ def compile(
 
     circ = QuantumCircuit.from_qasm_str(results.mapped_circuit)
     layout = extract_initial_layout_from_qasm(results.mapped_circuit, circ.qregs)
-    circ._layout = layout
+
+    # qiskit-terra 0.22.0 introduced a breaking change in the `_layout` of the `QuantumCircuit` class.
+    # To maintain backwards compatibility, the following `try... except` block is necessary.
+    try:
+        from qiskit.transpiler.layout import TranspileLayout
+
+        circ._layout = TranspileLayout(initial_layout=layout, input_qubit_mapping=layout.get_virtual_bits())
+    except ImportError:
+        circ._layout = layout
 
     return circ, results

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ setup(
         "importlib_resources>=5.9; python_version < '3.10'",
     ],
     extras_require={
-        "test": ["pytest>=7", "mqt.qcec~=2.0.0rc9"],
+        "test": ["pytest>=7", "mqt.qcec>=2"],
         "coverage": ["mqt.qmap[test]", "coverage[toml]>=6.4.2,<6.6.0", "pytest-cov>=3.0,<4.1"],
         "docs": [
             "sphinx>=5.1.1",

--- a/setup.py
+++ b/setup.py
@@ -106,19 +106,19 @@ setup(
     install_requires=[
         "qiskit-terra>=0.20.2",
         "retworkx[all]>=0.11.0,<0.12.0",
-        "importlib_resources>=5.9; python_version < '3.10'",
+        "importlib_resources>=5.0; python_version < '3.10'",
     ],
     extras_require={
         "test": ["pytest>=7", "mqt.qcec>=2"],
-        "coverage": ["mqt.qmap[test]", "coverage[toml]>=6.4.2,<6.6.0", "pytest-cov>=3.0,<4.1"],
+        "coverage": ["mqt.qmap[test]", "coverage[toml]>=6.3", "pytest-cov>=3"],
         "docs": [
-            "sphinx>=5.1.1",
+            "sphinx>=5",
             "sphinx-rtd-theme",
-            "sphinxcontrib-bibtex~=2.5",
+            "sphinxcontrib-bibtex>=2.4.2",
             "sphinx-copybutton",
-            "sphinx-hoverxref~=1.1.3",
+            "sphinx-hoverxref",
             "pybtex>=0.24",
-            "importlib_metadata>=3.6; python_version < '3.10'",
+            "importlib_metadata>=4.4; python_version < '3.10'",
         ],
         "dev": ["mqt.qmap[coverage, docs]"],  # requires Pip 21.2 or newer
     },

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     zip_safe=False,
     packages=find_namespace_packages(include=["mqt.*"]),
     install_requires=[
-        "qiskit-terra>=0.20.2,<0.23.0",
+        "qiskit-terra>=0.20.2",
         "retworkx[all]>=0.11.0,<0.12.0",
         "importlib_resources>=5.9; python_version < '3.10'",
     ],


### PR DESCRIPTION
## Description

This PR fixes an issue caused by a breaking change in the newest `qiskit-terra` update. The `_layout` member of `QuantumCircuit`s has been changed to a data class. This caused our circuit import and also the export to fail on the newer version.
This has not been caught earlier because QCEC (which is a test dependency) still capped qiskit-terra at `<0.22`.

In addition to the fix above, this PR loosens many of the dependency versions in order to avoid such situations in the future.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
