### PR TITLE
🔥 Drop deprecated JKQ shim

### DIFF
--- a/jkq/__init__.py
+++ b/jkq/__init__.py
@@ -1,9 +1,0 @@
-import warnings
-
-from mqt import qmap  # noqa: F401
-
-warnings.simplefilter("always", DeprecationWarning)
-warnings.warn(
-    "Usage via `import jkq` is deprecated in favor of the new prefix. Please use `import mqt` instead.",
-    DeprecationWarning,
-)


### PR DESCRIPTION
## Description

The transition from the JKQ framework to the Munich Quantum Toolkit has happened over a year ago. Thus, it is time to remove the deprecated `jkq` shim (which was never packaged with the Python package anyway). From this point on, QCEC only lives in the `mqt` namespace.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
