### PR TITLE
🐍🔧 Improve Python Testing Infrastructure

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -43,4 +43,4 @@ parsers:
 
 codecov:
   notify:
-    after_n_builds: 2
+    after_n_builds: 4

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -22,20 +22,48 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup nox
-        uses: excitedleigh/setup-nox@v2.1.0
+        run: pipx install nox
       - name: Run mypy via nox
         run: nox -s mypy
 
   python-tests:
-    name: Tests ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: 🐍 ${{ matrix.python-version }} Tests on ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.7", "3.11"]
+        include:
+          - runs-on: ubuntu-latest
+            python-version: "3.8"
+          - runs-on: ubuntu-latest
+            python-version: "3.9"
+          - runs-on: ubuntu-latest
+            python-version: "3.10"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Install Z3
+        uses: cda-tum/setup-z3@v1
+        with:
+          version: ${{ env.Z3_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup nox
+        run: pipx install nox
+      - name: Test on 🐍 ${{ matrix.python-version }}
+        run: nox -s tests-${{ matrix.python-version }}
+
+  min-qiskit-version:
+    name: ⚛️ Min. Qiskit Test
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -48,26 +76,43 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup nox
-        uses: excitedleigh/setup-nox@v2.1.0
-      - name: Test on 🐍 3.7
-        run: nox -s tests-3.7
-      # Python 3.8 and 3.9 are only tested on Linux.
-      - if: runner.os == 'Linux'
-        name: Test on 🐍 3.8
-        run: nox -s tests-3.8
-      - if: runner.os == 'Linux'
-        name: Test on 🐍 3.9
-        run: nox -s tests-3.9
-      # Python 3.10 under Linux is tested separately as part of the coverage job.
-      - if: runner.os != 'Linux'
-        name: Test on 🐍 3.10
-        run: nox -s tests-3.10
-      # Run the coverage job on Python 3.10 and upload the coverage data.
-      - if: runner.os == 'Linux'
-        name: Test and Coverage on 🐍 3.10
-        run: nox -s coverage-3.10 -- --cov-report=xml
-      - if: runner.os == 'Linux'
-        name: Upload Coverage to Codecov
+        run: pipx install nox
+      - name: Run session
+        run: nox -s min_qiskit_version -- --cov-report=xml
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v3.1.1
+        with:
+          fail_ci_if_error: true
+          flags: python
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  coverage:
+    name: 🐍 ${{ matrix.python-version }} Coverage
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.11"]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Install Z3
+        uses: cda-tum/setup-z3@v1
+        with:
+          version: ${{ env.Z3_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup nox
+        run: pipx install nox
+      - name: Run session
+        run: nox -s coverage-${{ matrix.python-version }} -- --cov-report=xml
+      - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3.1.1
         with:
           fail_ci_if_error: true

--- a/noxfile.py
+++ b/noxfile.py
@@ -45,6 +45,17 @@ def coverage(session: Session) -> None:
     session.run("pytest", "--cov", *session.posargs)
 
 
+@nox.session()
+def min_qiskit_version(session: Session) -> None:
+    """
+    Installs the minimum supported version of Qiskit, runs the test suite and collects the coverage.
+    """
+    session.install("qiskit-terra~=0.20.2")
+    session.install("-e", ".[coverage]")
+    session.run("pip", "show", "qiskit-terra")
+    session.run("pytest", "--cov", *session.posargs)
+
+
 @nox.session
 def lint(session: Session) -> None:
     """

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ from nox.sessions import Session
 
 nox.options.sessions = ["lint", "tests"]
 
-PYTHON_ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
+PYTHON_ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 if os.environ.get("CI", None):
     nox.options.error_on_missing_interpreters = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ include = ["mqt.*"]
 build = "cp3*"
 archs = "auto64"
 skip = "*-musllinux*"
-test-skip = "cp311-* *-macosx_arm64 *-musllinux* *aarch64"
+test-skip = "*-macosx_arm64"
 test-command = "python -c \"from mqt import qmap\""
 environment = { DEPLOY = "ON" }
 build-frontend = "build"


### PR DESCRIPTION
## Description

This PR adds further testing infrastructure to the Python side of QMAP:

- it adds a test run with the oldest `qiskit-terra` version we claim to support (mainly in order to make sure it actually works)
- it adds a coverage collection run for a different Python version (mainly to make sure that code that depends on the Python version is appropriately covered)
- it separates testing runs (which are executed on all systems with various Python versions) from coverage runs (which are only executed on Ubuntu with a selected set of Python versions)

Overall this should slightly increase the coverage metrics of the project and provide more safety that the library works as intended.
An additional benefit of the split is that CI runs a lot faster now since Python tests are no longer executed in sequence.

In addition:
- Qiskit now ships Python 3.11 wheels, so there is no reason left to not test under Python 3.11.
This PR adds the corresponding CI runs and modifies the existing ones.
- The `setup-nox` action (https://github.com/daisylb/setup-nox) isn't very well maintained. This PR drops it in favor of a simple `pipx install nox` and the corresponding Python setup.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
