### PR TITLE
♻️ consistently use `#pragma once`

### DIFF
--- a/include/Architecture.hpp
+++ b/include/Architecture.hpp
@@ -4,8 +4,7 @@
  * https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
-#ifndef QMAP_ARCHITECTURE_HPP
-#define QMAP_ARCHITECTURE_HPP
+#pragma once
 
 #include "configuration/AvailableArchitecture.hpp"
 #include "nlohmann/json.hpp"
@@ -394,5 +393,3 @@ protected:
                     const std::vector<std::vector<unsigned short>>& connections,
                     std::vector<int>& d, std::vector<bool>& visited);
 };
-
-#endif // QMAP_ARCHITECTURE_HPP

--- a/include/Mapper.hpp
+++ b/include/Mapper.hpp
@@ -4,8 +4,7 @@
  * https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
-#ifndef QMAP_MAPPER_HPP
-#define QMAP_MAPPER_HPP
+#pragma once
 
 #include "Architecture.hpp"
 #include "MappingResults.hpp"
@@ -264,5 +263,3 @@ public:
     results = MappingResults();
   }
 };
-
-#endif // QMAP_MAPPER_HPP

--- a/include/MappingResults.hpp
+++ b/include/MappingResults.hpp
@@ -11,8 +11,7 @@
 #include <sstream>
 #include <string>
 
-#ifndef QMAP_MAPPINGRESULTS_HPP
-#define QMAP_MAPPINGRESULTS_HPP
+#pragma once
 
 struct MappingResults {
   struct CircuitInfo {
@@ -113,5 +112,3 @@ struct MappingResults {
     return ss.str();
   }
 };
-
-#endif // QMAP_MAPPINGRESULTS_HPP

--- a/include/configuration/AvailableArchitecture.hpp
+++ b/include/configuration/AvailableArchitecture.hpp
@@ -4,8 +4,7 @@
  * https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
-#ifndef QMAP_AVAILABLEARCHITECTURE_HPP
-#define QMAP_AVAILABLEARCHITECTURE_HPP
+#pragma once
 
 #include <iostream>
 #include <map>
@@ -106,5 +105,3 @@ getCouplingMapSpecification(AvailableArchitecture architecture) {
        "8"}};
   return architectureMap.at(architecture);
 }
-
-#endif // QMAP_AVAILABLEARCHITECTURE_HPP

--- a/include/configuration/CommanderGrouping.hpp
+++ b/include/configuration/CommanderGrouping.hpp
@@ -4,8 +4,7 @@
  * https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
-#ifndef QMAP_COMMANDERGROUPING_HPP
-#define QMAP_COMMANDERGROUPING_HPP
+#pragma once
 
 #include <iostream>
 
@@ -39,5 +38,3 @@ groupingFromString(const std::string& grouping) {
     throw std::invalid_argument("Invalid grouping value: " + grouping);
   }
 }
-
-#endif // QMAP_COMMANDERGROUPING_HPP

--- a/include/configuration/Configuration.hpp
+++ b/include/configuration/Configuration.hpp
@@ -4,8 +4,7 @@
  * https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
-#ifndef QMAP_CONFIGURATION_HPP
-#define QMAP_CONFIGURATION_HPP
+#pragma once
 
 #include "CommanderGrouping.hpp"
 #include "Encoding.hpp"
@@ -125,5 +124,3 @@ struct Configuration {
 
   void setTimeout(unsigned int sec) { timeout = sec; }
 };
-
-#endif // QMAP_CONFIGURATION_HPP

--- a/include/configuration/Encoding.hpp
+++ b/include/configuration/Encoding.hpp
@@ -4,8 +4,7 @@
  * https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
-#ifndef QMAP_ENCODING_HPP
-#define QMAP_ENCODING_HPP
+#pragma once
 
 #include <iostream>
 
@@ -35,5 +34,3 @@ encodingFromString(const std::string& encoding) {
     throw std::invalid_argument("Invalid encoding value: " + encoding);
   }
 }
-
-#endif // QMAP_ENCODING_HPP

--- a/include/configuration/InitialLayout.hpp
+++ b/include/configuration/InitialLayout.hpp
@@ -4,8 +4,7 @@
  * https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
-#ifndef QMAP_INITIALLAYOUT_HPP
-#define QMAP_INITIALLAYOUT_HPP
+#pragma once
 
 #include <iostream>
 
@@ -43,5 +42,3 @@ initialLayoutFromString(const std::string& initialLayout) {
                                 initialLayout);
   }
 }
-
-#endif // QMAP_INITIALLAYOUT_HPP

--- a/include/configuration/Layering.hpp
+++ b/include/configuration/Layering.hpp
@@ -4,8 +4,7 @@
  * for more information.
  */
 
-#ifndef QMAP_LAYERING_HPP
-#define QMAP_LAYERING_HPP
+#pragma once
 
 #include <iostream>
 
@@ -49,5 +48,3 @@ layeringFromString(const std::string& layering) {
     throw std::invalid_argument("Invalid layering value: " + layering);
   }
 }
-
-#endif // QMAP_LAYERING_HPP

--- a/include/configuration/Method.hpp
+++ b/include/configuration/Method.hpp
@@ -4,8 +4,7 @@
  * https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
-#ifndef QMAP_METHOD_HPP
-#define QMAP_METHOD_HPP
+#pragma once
 
 #include <iostream>
 
@@ -34,5 +33,3 @@ static std::string toString(const Method method) {
     throw std::invalid_argument("Invalid method value: " + method);
   }
 }
-
-#endif // QMAP_METHOD_HPP

--- a/include/configuration/SwapReduction.hpp
+++ b/include/configuration/SwapReduction.hpp
@@ -4,8 +4,7 @@
  * https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
-#ifndef QMAP_SWAPREDUCTION_HPP
-#define QMAP_SWAPREDUCTION_HPP
+#pragma once
 
 #include <iostream>
 
@@ -39,5 +38,3 @@ swapReductionFromString(const std::string& reduction) {
     throw std::invalid_argument("Invalid swap reduction value: " + reduction);
   }
 }
-
-#endif // QMAP_SWAPREDUCTION_HPP

--- a/include/exact/ExactMapper.hpp
+++ b/include/exact/ExactMapper.hpp
@@ -4,8 +4,7 @@
  * https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
-#ifndef EXACT_MAPPER_hpp
-#define EXACT_MAPPER_hpp
+#pragma once
 
 #include "Mapper.hpp"
 
@@ -36,5 +35,3 @@ protected:
 public:
   void map(const Configuration& settings) override;
 };
-
-#endif /* EXACT_MAPPER_hpp */

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -7,8 +7,7 @@
 #include "Mapper.hpp"
 #include "heuristic/unique_priority_queue.hpp"
 
-#ifndef QMAP_HEURISTICMAPPER_HPP
-#define QMAP_HEURISTICMAPPER_HPP
+#pragma once
 
 class HeuristicMapper : public Mapper {
 public:
@@ -348,5 +347,3 @@ inline bool operator>(const HeuristicMapper::Node& x,
     return x < y;
   }
 }
-
-#endif // QMAP_HEURISTICMAPPER_HPP

--- a/include/heuristic/unique_priority_queue.hpp
+++ b/include/heuristic/unique_priority_queue.hpp
@@ -10,8 +10,7 @@
 #include <set>
 #include <vector>
 
-#ifndef UNIQUE_PRIORITY_QUEUE_H
-#define UNIQUE_PRIORITY_QUEUE_H
+#pragma once
 
 #define UNUSED(x)                                                              \
   { (void)x; }
@@ -148,4 +147,3 @@ private:
   std::set<T, FuncCompare>                           membership_;
   unsigned int                                       last_node_copied = 0;
 };
-#endif

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -4,8 +4,7 @@
  * https://www.cda.cit.tum.de/research/ibm_qx_mapping/ for more information.
  */
 
-#ifndef QMAP_UTILS_HPP
-#define QMAP_UTILS_HPP
+#pragma once
 
 #include <algorithm>
 #include <functional>
@@ -154,4 +153,3 @@ void parse_line(const std::string& line, char separator,
                 std::vector<std::string>& result);
 std::set<std::pair<unsigned short, unsigned short>>
 getFullyConnectedMap(unsigned short nQubits);
-#endif // QMAP_UTILS_HPP


### PR DESCRIPTION
## Description

The use of [`#pragma once`](https://en.wikipedia.org/wiki/Pragma_once) in favor of include guards comes with several advantages, including: less code, avoidance of name clashes, and sometimes improvement in compilation speed.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
