### PR TITLE
🚨🐛 Disable opinionated bugbear warning

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 extend-select = B9, C4, TC, TC1
-extend-ignore = E203, E231, E501, E722, W503, B950, B014, W504, E123, E126, E226, E121
+extend-ignore = E203, E231, E501, E722, W503, B950, B014, W504, E123, E126, E226, E121, B905
 max-line-length = 120
 show-source = true
 exclude =


### PR DESCRIPTION
## Description

`flake8-bugbear` recently introduced the following opinionated warning:

> B905: zip() without an explicit strict= parameter set. strict=True causes the resulting iterator to raise a ValueError if the arguments are exhausted at differing lengths. The strict= argument was added in Python 3.10, so don't enable this flag for code that should work on <3.10. For more information: https://peps.python.org/pep-0618/

As stated, this only applies to Python 3.10+ and cannot be resolved for older Python versions. As a consequence, we disable that check for the foreseeable future.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
