### PR TITLE
🔥 Remove Z3 from build dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,15 +9,9 @@ build:
   tools:
     python: "3.10"
   jobs:
-    pre_create_environment:
-      - pip install "z3-solver>=4.8.15"
-      - echo python -c "import z3 as _; print(_.__path__[0])"
     post_create_environment:
       - pip install "z3-solver>=4.8.15"
-      - python -c "import z3 as _; print(_.__path__[0])"
-      - Z3_ROOT=$(python -c "import z3 as _; print(_.__path__[0])"); echo $Z3_ROOT
-      - echo $(python -c "import z3 as _; print(_.__path__[0])")
-      - export Z3_ROOT=$(python -c "import z3 as _; print(_.__path__[0])") && pip install -e .[docs] -v
+      - Z3_ROOT=$(python -c "import z3 as _; print(_.__path__[0])"); export Z3_ROOT; pip install -e .[docs] -v
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,15 +11,13 @@ build:
   jobs:
     pre_create_environment:
       - pip install "z3-solver>=4.8.15"
-      - python -c "import z3 as _; print(_.__path__)"
+      - echo python -c "import z3 as _; print(_.__path__[0])"
     post_create_environment:
       - pip install "z3-solver>=4.8.15"
-      - python -c "import z3 as _; print(_.__path__)"
-      - export Z3_ROOT=$(python -c "import z3 as _; print(_.__path__)") && pip install -e .[docs] -v
-    pre_install:
-      - python -c "import z3 as _; print(_.__path__)"
-    post_install:
-      - python -c "import z3 as _; print(_.__path__)"
+      - python -c "import z3 as _; print(_.__path__[0])"
+      - Z3_ROOT=$(python -c "import z3 as _; print(_.__path__[0])"); echo $Z3_ROOT
+      - echo $(python -c "import z3 as _; print(_.__path__[0])")
+      - export Z3_ROOT=$(python -c "import z3 as _; print(_.__path__[0])") && pip install -e .[docs] -v
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,8 +9,8 @@ build:
   tools:
     python: "3.10"
   jobs:
-    pre_install:
-      - pip install "z3-solver>=4.8.15"
+    post_install:
+      - python -m pip install "z3-solver>=4.8.15"
       - export Z3_ROOT=$(python -c "import z3 as _; print(_.__path__)") && pip install --upgrade --upgrade-strategy eager --no-cache-dir .[docs] -v
 
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,9 +9,17 @@ build:
   tools:
     python: "3.10"
   jobs:
+    pre_create_environment:
+      - pip install "z3-solver>=4.8.15"
+      - python -c "import z3 as _; print(_.__path__)"
+    post_create_environment:
+      - pip install "z3-solver>=4.8.15"
+      - python -c "import z3 as _; print(_.__path__)"
+      - export Z3_ROOT=$(python -c "import z3 as _; print(_.__path__)") && pip install -e .[docs] -v
+    pre_install:
+      - python -c "import z3 as _; print(_.__path__)"
     post_install:
-      - python -m pip install "z3-solver>=4.8.15"
-      - export Z3_ROOT=$(python -c "import z3 as _; print(_.__path__)") && pip install --upgrade --upgrade-strategy eager --no-cache-dir .[docs] -v
+      - python -c "import z3 as _; print(_.__path__)"
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,7 @@ build:
   jobs:
     pre_create_environment:
       - pip install "z3-solver>=4.8.15"
+      - python -c "import z3 as _; print(_.__path__)"
 
 sphinx:
   configuration: docs/source/conf.py
@@ -23,4 +24,3 @@ python:
       path: .
       extra_requirements:
         - docs
-  system_packages: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,9 @@ build:
     python: "3.9"
   apt_packages:
     - cmake
+  jobs:
+    pre_create_environment:
+      - pip install "z3-solver>=4.8.15"
 
 sphinx:
   configuration: docs/source/conf.py
@@ -20,3 +23,4 @@ python:
       path: .
       extra_requirements:
         - docs
+  system_packages: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ submodules:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
   jobs:
     pre_install:
       - pip install "z3-solver>=4.8.15"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,8 +8,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.9"
-  apt_packages:
-    - cmake
   jobs:
     pre_create_environment:
       - pip install "z3-solver>=4.8.15"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,16 +9,9 @@ build:
   tools:
     python: "3.9"
   jobs:
-    pre_create_environment:
+    pre_install:
       - pip install "z3-solver>=4.8.15"
-      - python -c "import z3 as _; print(_.__path__)"
+      - export Z3_ROOT=$(python -c "import z3 as _; print(_.__path__)") && pip install --upgrade --upgrade-strategy eager --no-cache-dir .[docs] -v
 
 sphinx:
   configuration: docs/source/conf.py
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ requires = [
     "setuptools_scm[toml]>=7",
     "ninja>=1.10; sys_platform != 'win32'",
     "cmake>=3.19",
-    "z3-solver>=4.8.15,<4.12.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
## Description

This PR gets rid of the Z3 build dependency. Due to build isolation, the virtual environment containing Z3 (that is being linked to the C++ binding library) does no longer exist after the build. Hence, the package install is essentially broken if the Z3 Python package is picked up during the build.

This was a workaround for getting the RtD build to work. I managed to work around the underlying issue by figuring out a way to specify the `Z3_ROOT` environment variable for the package installation step.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
