### PR TITLE
🐛 fix missing macOS x86 wheels

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,8 @@ jobs:
           architecture: ${{ matrix.config.arch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - if: ${{ matrix.config.arch }} == 'arm64'
+      - if: ${{ matrix.config.arch == 'arm64' }}
+        name: Set Architecture to arm64 if necessary
         run: echo "CIBW_ARCHS_MACOS=arm64" >> $GITHUB_ENV
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.3


### PR DESCRIPTION
## Description

Due to a misconfiguration in the CI, x86 wheels for macOS were no longer being built. This PR fixes the underlying issue. Thanks @hillmich for noticing!

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
