### PR TITLE
✨Heuristic mapper fidelity preparation

### DIFF
--- a/include/configuration/Configuration.hpp
+++ b/include/configuration/Configuration.hpp
@@ -38,6 +38,7 @@ struct Configuration {
   // lookahead scheme settings
   bool   lookahead            = true;
   bool   admissibleHeuristic  = true;
+  bool   considerFidelity     = true;
   int    nrLookaheads         = 15;
   double firstLookaheadFactor = 0.75;
   double lookaheadFactor      = 0.5;
@@ -86,6 +87,7 @@ struct Configuration {
       if (lookahead) {
         auto& lookaheadSettings                   = heuristic["lookahead"];
         lookaheadSettings["admissible_heuristic"] = admissibleHeuristic;
+        lookaheadSettings["consider_fidelity"]    = considerFidelity;
         lookaheadSettings["lookaheads"]           = nrLookaheads;
         lookaheadSettings["first_factor"]         = firstLookaheadFactor;
         lookaheadSettings["factor"]               = lookaheadFactor;

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -33,7 +33,6 @@ public:
     /** heuristic cost expected for future swaps needed in later circuit layers
      * (further layers contribute less) */
     double lookaheadPenalty = 0.;
-    double costTotal        = 0.;
     /**
      * containing the logical qubit currently mapped to each physical qubit.
      * `qubits[physical_qubit] = logical_qubit`
@@ -179,7 +178,6 @@ public:
       out << "\t\"cost\": {\n";
       out << "\t\t\"fixed\": " << costFixed << ",\n";
       out << "\t\t\"heuristic\": " << costHeur << ",\n";
-      out << "\t\t\"total\": " << costTotal << ",\n";
       out << "\t\t\"lookahead_penalty\": " << lookaheadPenalty << "\n";
       out << "\t},\n";
       out << "\t\"nswaps\": " << nswaps << "\n}\n";
@@ -324,9 +322,9 @@ inline bool operator<(const HeuristicMapper::Node& x,
 inline bool operator>(const HeuristicMapper::Node& x,
                       const HeuristicMapper::Node& y) {
   const auto xcost =
-      x.costTotal + static_cast<double>(x.costFixed) + x.lookaheadPenalty;
+      static_cast<double>(x.costFixed) + x.lookaheadPenalty;
   const auto ycost =
-      y.costTotal + static_cast<double>(y.costFixed) + y.lookaheadPenalty;
+      static_cast<double>(y.costFixed) + y.lookaheadPenalty;
   if (std::abs(xcost - ycost) > 1e-6) {
     return xcost > ycost;
   }

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -177,8 +177,6 @@ public:
         auto cost          = arch.distance(locations.at(gate.control),
                                            locations.at(gate.target));
         auto fidelity_cost = cost;
-        if (considerFidelity) {
-        }
         if (admissibleHeuristic) {
           costHeur = std::max(costHeur, fidelity_cost);
         } else {
@@ -260,7 +258,6 @@ protected:
    * Additionally sets the fields `costHeur` (maximum distance between any 2
    * qubits which share a gate) and `done` (all qubit considered pairs are
    * mapped next to each other) in the current search node.
-   *heuristic specified
    * @param layer index of the circuit layer to consider
    * @param node current AStar search node
    * @param consideredQubits vector in which to gather all relevant qubits of

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -149,29 +149,35 @@ public:
 
       swaps.back().emplace_back(source, target, middle_anc, qc::Teleportation);
     }
-    
+
     /**
-     * @brief calculates the heuristic cost of the current mapping in the node for some given layer and writes it to `Node::costHeur`
-     * additional `Node::done` is set to true if all qubits shared by a gate in the layer are mapped next to each other
-     * 
-     * @param arch the architecture for calculating distances between physical qubits
+     * @brief calculates the heuristic cost of the current mapping in the node
+     * for some given layer and writes it to `Node::costHeur` additional
+     * `Node::done` is set to true if all qubits shared by a gate in the layer
+     * are mapped next to each other
+     *
+     * @param arch the architecture for calculating distances between physical
+     * qubits
      * @param currentLayer a vector of all gates in the current layer
-     * @param admissibleHeuristic controls if the heuristic should be calculated such that it is admissible 
-     *  (i.e. A*-search should yield the optimal solution using this heuristic)
-     * @param considerFidelity controls if the heuristic should consider fidelity data of the architecture
+     * @param admissibleHeuristic controls if the heuristic should be calculated
+     * such that it is admissible (i.e. A*-search should yield the optimal
+     * solution using this heuristic)
+     * @param considerFidelity controls if the heuristic should consider
+     * fidelity data of the architecture
      */
-    void updateHeuristicCost(const Architecture& arch, const std::vector<Gate>& currentLayer,
+    void updateHeuristicCost(const Architecture&      arch,
+                             const std::vector<Gate>& currentLayer,
                              bool admissibleHeuristic, bool considerFidelity) {
       costHeur = 0.;
-      done = true;
+      done     = true;
       for (const auto& gate : currentLayer) {
         if (gate.singleQubit())
           continue;
-        
-        auto cost = arch.distance(locations.at(gate.control), locations.at(gate.target));
+
+        auto cost          = arch.distance(locations.at(gate.control),
+                                           locations.at(gate.target));
         auto fidelity_cost = cost;
-        if(considerFidelity){
-          
+        if (considerFidelity) {
         }
         if (admissibleHeuristic) {
           costHeur = std::max(costHeur, fidelity_cost);
@@ -332,10 +338,8 @@ inline bool operator<(const HeuristicMapper::Node& x,
 
 inline bool operator>(const HeuristicMapper::Node& x,
                       const HeuristicMapper::Node& y) {
-  const auto xcost =
-      static_cast<double>(x.costFixed) + x.lookaheadPenalty;
-  const auto ycost =
-      static_cast<double>(y.costFixed) + y.lookaheadPenalty;
+  const auto xcost = static_cast<double>(x.costFixed) + x.lookaheadPenalty;
+  const auto ycost = static_cast<double>(y.costFixed) + y.lookaheadPenalty;
   if (std::abs(xcost - ycost) > 1e-6) {
     return xcost > ycost;
   }

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -158,9 +158,10 @@ public:
      * @param currentLayer a vector of all gates in the current layer
      * @param admissibleHeuristic controls if the heuristic should be calculated such that it is admissible 
      *  (i.e. A*-search should yield the optimal solution using this heuristic)
+     * @param considerFidelity controls if the heuristic should consider fidelity data of the architecture
      */
     void updateHeuristicCost(const Architecture& arch, const std::vector<Gate>& currentLayer,
-                             bool admissibleHeuristic) {
+                             bool admissibleHeuristic, bool considerFidelity) {
       costHeur = 0.;
       done = true;
       for (const auto& gate : currentLayer) {
@@ -168,10 +169,14 @@ public:
           continue;
         
         auto cost = arch.distance(locations.at(gate.control), locations.at(gate.target));
+        auto fidelity_cost = cost;
+        if(considerFidelity){
+          
+        }
         if (admissibleHeuristic) {
-          costHeur = std::max(costHeur, cost);
+          costHeur = std::max(costHeur, fidelity_cost);
         } else {
-          costHeur += cost;
+          costHeur += fidelity_cost;
         }
         if (cost > COST_DIRECTION_REVERSE) {
           done = false;

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -184,6 +184,8 @@ PYBIND11_MODULE(pyqmap, m) {
       .def_readwrite("lookahead", &Configuration::lookahead)
       .def_readwrite("admissible_heuristic",
                      &Configuration::admissibleHeuristic)
+      .def_readwrite("consider_fidelity",
+                     &Configuration::considerFidelity)
       .def_readwrite("lookaheads", &Configuration::nrLookaheads)
       .def_readwrite("first_lookahead_factor",
                      &Configuration::firstLookaheadFactor)

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -184,8 +184,7 @@ PYBIND11_MODULE(pyqmap, m) {
       .def_readwrite("lookahead", &Configuration::lookahead)
       .def_readwrite("admissible_heuristic",
                      &Configuration::admissibleHeuristic)
-      .def_readwrite("consider_fidelity",
-                     &Configuration::considerFidelity)
+      .def_readwrite("consider_fidelity", &Configuration::considerFidelity)
       .def_readwrite("lookaheads", &Configuration::nrLookaheads)
       .def_readwrite("first_lookahead_factor",
                      &Configuration::firstLookaheadFactor)

--- a/mqt/qmap/pyqmap.pyi
+++ b/mqt/qmap/pyqmap.pyi
@@ -109,6 +109,7 @@ class CommanderGrouping:
 class Configuration:
     add_measurements_to_mapped_circuit: bool
     admissible_heuristic: bool
+    consider_fidelity: bool
     commander_grouping: CommanderGrouping
     enable_limits: bool
     encoding: Encoding

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -385,7 +385,7 @@ HeuristicMapper::Node HeuristicMapper::AstarMap(long layer) {
 
   node.locations = locations;
   node.qubits    = qubits;
-  node.updateHeuristicCost(architecture, layers.at(layer), results.config.admissibleHeuristic);
+  node.updateHeuristicCost(architecture, layers.at(layer), results.config.admissibleHeuristic, results.config.considerFidelity);
 
   nodes.push(node);
 
@@ -498,9 +498,8 @@ void HeuristicMapper::expand_node_add_one_swap(const Edge& swap, Node& node,
     new_node.costFixed = node.costFixed + COST_TELEPORTATION;
     new_node.applyTeleportation(swap, architecture);
   }
-  new_node.done      = true;
 
-  new_node.updateHeuristicCost(architecture, currentLayer, results.config.admissibleHeuristic);
+  new_node.updateHeuristicCost(architecture, currentLayer, results.config.admissibleHeuristic, results.config.considerFidelity);
 
   // calculate heuristics for the cost of the following layers
   if (config.lookahead) {

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -507,7 +507,6 @@ void HeuristicMapper::expand_node_add_one_swap(const Edge& swap, Node& node,
     new_node.costFixed = node.costFixed + COST_TELEPORTATION;
     new_node.applyTeleportation(swap, architecture);
   }
-  new_node.costTotal = new_node.costFixed;
   new_node.done      = true;
 
   for (const auto& gate : currentLayer) {

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -385,7 +385,9 @@ HeuristicMapper::Node HeuristicMapper::AstarMap(long layer) {
 
   node.locations = locations;
   node.qubits    = qubits;
-  node.updateHeuristicCost(architecture, layers.at(layer), results.config.admissibleHeuristic, results.config.considerFidelity);
+  node.updateHeuristicCost(architecture, layers.at(layer),
+                           results.config.admissibleHeuristic,
+                           results.config.considerFidelity);
 
   nodes.push(node);
 
@@ -499,7 +501,9 @@ void HeuristicMapper::expand_node_add_one_swap(const Edge& swap, Node& node,
     new_node.applyTeleportation(swap, architecture);
   }
 
-  new_node.updateHeuristicCost(architecture, currentLayer, results.config.admissibleHeuristic, results.config.considerFidelity);
+  new_node.updateHeuristicCost(architecture, currentLayer,
+                               results.config.admissibleHeuristic,
+                               results.config.considerFidelity);
 
   // calculate heuristics for the cost of the following layers
   if (config.lookahead) {


### PR DESCRIPTION
## Description

- isolated the heuristic to HeuristicMapper::Node::updateHeuristicCost for less redundant code and easier expansion with further heuristic types (e.g. the planned fidelity aware approach)
- removed redundant field HeuristicMapper::Node::totalCost (redundant to HeuristicMapper::Node::costFixed)
- added consider_fidelity field to configuration classes

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
