### PR TITLE
🐛 Fix Coupling Limit Computation

### DIFF
--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -552,8 +552,9 @@ void Architecture::findCouplingLimit(
   }
   visited[node] = true;
 
-  if (d.at(node) < curSum) {
-    d[node] = curSum;
+  auto& elem = d[node];
+  if (elem == 0 || elem > curSum) {
+    elem = curSum;
   }
   if (connections.at(node).empty()) {
     visited[node] = false;

--- a/test/test_architecture.cpp
+++ b/test/test_architecture.cpp
@@ -152,3 +152,11 @@ TEST(TestArchitecture, MinimumNumberOfSwapsError) {
   EXPECT_THROW(architecture.minimumNumberOfSwaps(permutation, swaps),
                std::runtime_error);
 }
+
+TEST(TestArchitecture, TestCouplingLimitRing) {
+  Architecture      architecture{};
+  const CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 3},
+                          {3, 2}, {3, 4}, {4, 3}, {4, 0}, {0, 4}};
+  architecture.loadCouplingMap(5, cm);
+  EXPECT_EQ(architecture.getCouplingLimit(), 2);
+}


### PR DESCRIPTION
## Description

For whatever reason, the computation of the coupling limit of an architecture is broken since its introduction.
It remains unclear, why this was not detected earlier, but definitely shows the lack of tests for that feature.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
