### PR TITLE
🐛 Fix Circuit Extraction in Exact Mapper

### DIFF
--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -256,15 +256,12 @@ void ExactMapper::map(const Configuration& settings) {
   for (std::size_t i = 0U; i < layers.size(); ++i) {
     if (i == 0U) {
       qcMapped.initialLayout.clear();
-      qcMapped.outputPermutation.clear();
 
       // no swaps but initial permutation
       for (const auto& [physical, logical] : *swapsIterator) {
         locations.at(logical) = static_cast<std::int16_t>(physical);
         qubits.at(physical)   = static_cast<std::int16_t>(logical);
         qcMapped.initialLayout[static_cast<qc::Qubit>(physical)] =
-            static_cast<qc::Qubit>(logical);
-        qcMapped.outputPermutation[static_cast<qc::Qubit>(physical)] =
             static_cast<qc::Qubit>(logical);
       }
 
@@ -371,6 +368,13 @@ void ExactMapper::map(const Configuration& settings) {
       ++swapsIterator;
       ++layerIterator;
     }
+  }
+
+  // set output permutation
+  qcMapped.outputPermutation.clear();
+  for (qc::Qubit logical = 0; logical < qc.getNqubits(); ++logical) {
+    const auto physical = static_cast<qc::Qubit>(locations[logical]);
+    qcMapped.outputPermutation[physical] = logical;
   }
 
   // 9) apply post mapping optimizations

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -348,8 +348,8 @@ void ExactMapper::map(const Configuration& settings) {
         const auto logical1  = static_cast<qc::Qubit>(qubits.at(q1));
         qcMapped.swap(q0, q1);
         std::swap(qubits.at(q0), qubits.at(q1));
-        locations[logical0] = static_cast<std::int16_t>(q1);
-        locations[logical1] = static_cast<std::int16_t>(q0);
+        locations.at(logical0) = static_cast<std::int16_t>(q1);
+        locations.at(logical1) = static_cast<std::int16_t>(q0);
 
         if (settings.verbose) {
           std::cout << "Qubits: ";
@@ -372,7 +372,7 @@ void ExactMapper::map(const Configuration& settings) {
   // set output permutation
   qcMapped.outputPermutation.clear();
   for (qc::Qubit logical = 0; logical < qc.getNqubits(); ++logical) {
-    const auto physical = static_cast<qc::Qubit>(locations[logical]);
+    const auto physical = static_cast<qc::Qubit>(locations.at(logical));
     qcMapped.outputPermutation[physical] = logical;
   }
 

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -272,8 +272,13 @@ void ExactMapper::map(const Configuration& settings) {
       placeRemainingArchitectureQubits();
 
       if (settings.verbose) {
+        std::cout << "Qubits: ";
         for (auto q = 0U; q < architecture.getNqubits(); ++q) {
           std::cout << qubits.at(q) << " ";
+        }
+        std::cout << " Locations: ";
+        for (std::size_t q = 0; q < qc.getNqubits(); ++q) {
+          std::cout << locations.at(q) << " ";
         }
         std::cout << std::endl;
       }
@@ -351,8 +356,13 @@ void ExactMapper::map(const Configuration& settings) {
             locations.at(static_cast<std::size_t>(qubits.at(swap.second))));
 
         if (settings.verbose) {
+          std::cout << "Qubits: ";
           for (auto q = 0U; q < architecture.getNqubits(); ++q) {
             std::cout << qubits.at(q) << " ";
+          }
+          std::cout << " Locations: ";
+          for (std::size_t q = 0; q < qc.getNqubits(); ++q) {
+            std::cout << locations.at(q) << " ";
           }
           std::cout << std::endl;
         }

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -343,14 +343,13 @@ void ExactMapper::map(const Configuration& settings) {
       // apply swaps before layer
       for (auto it = (*swapsIterator).rbegin(); it != (*swapsIterator).rend();
            ++it) {
-        auto& swap = *it;
-        qcMapped.swap(swap.first, swap.second);
-        std::swap(qcMapped.outputPermutation.at(swap.first),
-                  qcMapped.outputPermutation.at(swap.second));
-        std::swap(qubits.at(swap.first), qubits.at(swap.second));
-        std::swap(
-            locations.at(static_cast<std::size_t>(qubits.at(swap.first))),
-            locations.at(static_cast<std::size_t>(qubits.at(swap.second))));
+        const auto& [q0, q1] = *it;
+        const auto logical0  = static_cast<qc::Qubit>(qubits.at(q0));
+        const auto logical1  = static_cast<qc::Qubit>(qubits.at(q1));
+        qcMapped.swap(q0, q1);
+        std::swap(qubits.at(q0), qubits.at(q1));
+        locations[logical0] = static_cast<std::int16_t>(q1);
+        locations[logical1] = static_cast<std::int16_t>(q0);
 
         if (settings.verbose) {
           std::cout << "Qubits: ";


### PR DESCRIPTION
## Description

Recent experiments have identified an error in the circuit extraction procedure of the exact mapper when the mapped circuit uses more qubits than the original circuit.
This PR resolves the errors by properly handling these cases.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
