### PR TITLE
🐍🔥 Drop Python 3.7 support

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -33,10 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.11"]
+        python-version: ["3.8", "3.11"]
         include:
-          - runs-on: ubuntu-latest
-            python-version: "3.8"
           - runs-on: ubuntu-latest
             python-version: "3.9"
           - runs-on: ubuntu-latest
@@ -92,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.11"]
+        python-version: ["3.8", "3.11"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     rev: "v3.3.1"
     hooks:
       - id: pyupgrade
-        args: ["--py37-plus"]
+        args: ["--py38-plus"]
 
   # Sort includes
   - repo: https://github.com/PyCQA/isort

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ from nox.sessions import Session
 
 nox.options.sessions = ["lint", "tests"]
 
-PYTHON_ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
 
 if os.environ.get("CI", None):
     nox.options.error_on_missing_interpreters = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ license = { file = "LICENSE.md" }
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -37,7 +36,7 @@ classifiers=[
     "Natural Language :: English",
     "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "qiskit-terra>=0.20.2",
     "rustworkx[all]>=0.12.0",
@@ -127,7 +126,7 @@ src_paths = ["mqt/qmap", "test/python"]
 
 [tool.mypy]
 files = ["mqt/qmap", "test/python", "setup.py"]
-python_version = "3.7"
+python_version = "3.8"
 strict = true
 show_error_codes = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
@@ -139,7 +138,7 @@ module = ["qiskit.*", "rustworkx.*", "matplotlib.*", "mqt.qcec.*"]
 ignore_missing_imports = true
 
 [tool.pylint]
-master.py-version = "3.7"
+master.py-version = "3.8"
 master.jobs = "0"
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"


### PR DESCRIPTION
## Description

Qiskit(-terra) is bound to drop Python 3.7 support in the upcoming `0.25.0` update and a warning is issued since the newly released `0.23.0`. 
To avoid any future disruptions, Python 3.7 support is dropped with this PR.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
