### PR TITLE
🔥 Drop variable limitation for exact mapper

### DIFF
--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -56,33 +56,6 @@ void ExactMapper::map(const Configuration& settings) {
     return;
   }
 
-  std::uint64_t factorial = 1;
-  for (std::size_t i = 2; i <= qc.getNqubits(); ++i) {
-    factorial *= i;
-  }
-  auto maxIndex = factorial * reducedLayerIndices.size();
-  if (maxIndex > std::numeric_limits<int>::max()) {
-    std::cerr << "The exact approach can only be used for up to "
-              << std::numeric_limits<int>::max()
-              << " permutation variables, due to 'layers * nq!' overflowing "
-                 "Z3's expr_vector class (uses 'int' index) when trying to "
-                 "instantiate permutation variables y_k_pi. Try reducing the "
-                 "number of layers or the number of qubits."
-              << std::endl;
-    return;
-  }
-
-  maxIndex = qc.getNqubits() * qc.getNqubits() * reducedLayerIndices.size();
-  if (maxIndex > std::numeric_limits<int>::max()) {
-    std::cerr << "The exact approach can only be used for up to "
-              << std::numeric_limits<int>::max()
-              << " X variables, due to nq*nq*nlayers overflowing Z3's "
-                 "expr_vector class (uses 'int' index). Try reducing the "
-                 "number of layers or the number of qubits."
-              << std::endl;
-    return;
-  }
-
   // 2) For all possibilities k (=m over n) to pick n qubits from m physical
   // qubits
   std::vector<std::uint16_t> qubitRange{};


### PR DESCRIPTION
## Description

It turns out that the limitation on the number of variables in the exact mapper is no longer required since the introduction of the LogicBlocks submodule as it does not use Z3's `expr_vector` directly. 
This should allow to map circuits with more gates (and maybe even more qubits in some cases) than before.

@pehamTom might be interesting to you since you hit that limitation a couple days back.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
