### PR TITLE
🔧 mypy configuration update

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -21,10 +21,12 @@ jobs:
     name: Run my[py] linter
     steps:
       - uses: actions/checkout@v3
-      - name: Setup nox
-        run: pipx install nox
-      - name: Run mypy via nox
-        run: nox -s mypy
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: mypy --all-files
 
   python-tests:
     name: 🐍 ${{ matrix.python-version }} Tests on ${{ matrix.runs-on }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,6 @@ repos:
     rev: "v0.991"
     hooks:
       - id: mypy
-        stages: [manual]
         files: ^(mqt/qmap|test/python|setup.py)
         args: []
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,7 +108,6 @@ repos:
         args: []
         additional_dependencies:
           - "importlib_resources"
-          - "numpy"
           - "pytest>=7.0"
           - "types-setuptools"
           - "mqt.qcec"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@
 ci:
   autoupdate_commit_msg: "⬆️🪝 update pre-commit hooks"
   autofix_commit_msg: "🎨 pre-commit fixes"
-  skip: [ mypy ]
+  skip: [mypy]
 
 repos:
   # Standard hooks
@@ -111,6 +111,7 @@ repos:
           - "numpy"
           - "pytest>=7.0"
           - "types-setuptools"
+          - "mqt.qcec"
 
   # Check for spelling
   - repo: https://github.com/codespell-project/codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@
 ci:
   autoupdate_commit_msg: "⬆️🪝 update pre-commit hooks"
   autofix_commit_msg: "🎨 pre-commit fixes"
+  skip: [ mypy ]
 
 repos:
   # Standard hooks

--- a/noxfile.py
+++ b/noxfile.py
@@ -90,7 +90,7 @@ def mypy(session: Session) -> None:
     Simply execute `nox -rs mypy` to run mypy.
     """
     session.install("pre-commit")
-    session.run("pre-commit", "run", "--all-files", "--hook-stage", "manual", "mypy", *session.posargs)
+    session.run("pre-commit", "run", "mypy", "--all-files", *session.posargs)
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ warn_unreachable = true
 explicit_package_bases = true
 
 [[tool.mypy.overrides]]
-module = ["qiskit.*", "rustworkx.*", "matplotlib.*", "mqt.qcec.*"]
+module = ["qiskit.*", "rustworkx.*", "matplotlib.*"]
 ignore_missing_imports = true
 
 [tool.pylint]


### PR DESCRIPTION
## Description

I recently found out that you can explicitly exclude pre-commit checks from the CI bot, so that they are never really initialised. This allows to incorporate `mqt.qcec` (and in turn `qiskit-terra`) to be included in the type checking; previously this exceeded the memory capacity of the pre-commit.ci service.

With this change, `mypy` is also included in the default pre-commit checks when run locally. Expect a slight runtime increase the first time trying to run pre-commit or its git hooks after this change as mypy build sup its cache.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
