### PR TITLE
🔧 add `merge_group` to workflow configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: C++
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,6 +3,7 @@ name: "CodeQL"
 on:
   push:
   pull_request:
+  merge_group:
   schedule:
     - cron: "15 21 * * 6"
   workflow_dispatch:

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -2,6 +2,7 @@ name: cpp-linter
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   release:
     types: [published]
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -2,6 +2,7 @@ name: Python
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
## Description

This tiny PR adds the `merge_group` label to the GitHub workflows in order to make them work with merge queues.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
