### PR TITLE
Support any two qubit gates

### DIFF
--- a/include/MappingResults.hpp
+++ b/include/MappingResults.hpp
@@ -19,7 +19,7 @@ struct MappingResults {
     std::uint16_t qubits           = 0;
     std::size_t   gates            = 0;
     std::size_t   singleQubitGates = 0;
-    std::size_t   cnots            = 0;
+    std::size_t   twoQubitGates    = 0;
     std::size_t   layers           = 0;
 
     // info in output circuit
@@ -62,14 +62,14 @@ struct MappingResults {
     circuit["qubits"]             = input.qubits;
     circuit["gates"]              = input.gates;
     circuit["single_qubit_gates"] = input.singleQubitGates;
-    circuit["cnots"]              = input.cnots;
+    circuit["cnots"]              = input.twoQubitGates;
 
     auto& mappedCirc                 = resultJSON["mapped_circuit"];
     mappedCirc["name"]               = output.name;
     mappedCirc["qubits"]             = output.qubits;
     mappedCirc["gates"]              = output.gates;
     mappedCirc["single_qubit_gates"] = output.singleQubitGates;
-    mappedCirc["cnots"]              = output.cnots;
+    mappedCirc["cnots"]              = output.twoQubitGates;
     if (!mappedCircuit.empty()) {
       mappedCirc["qasm"] = mappedCircuit;
     }
@@ -100,9 +100,9 @@ struct MappingResults {
   virtual std::string csv() {
     std::stringstream ss{};
     ss << input.name << ";" << input.qubits << ";" << input.gates << ";"
-       << input.singleQubitGates << ";" << input.cnots << ";" << architecture
+       << input.singleQubitGates << ";" << input.twoQubitGates << ";" << architecture
        << ";" << output.name << ";" << output.qubits << ";" << output.gates
-       << ";" << output.singleQubitGates << ";" << output.cnots << ";"
+       << ";" << output.singleQubitGates << ";" << output.twoQubitGates << ";"
        << output.swaps << ";" << output.directionReverse << ";"
        << output.teleportations << ";";
     if (timeout) {

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -240,7 +240,8 @@ PYBIND11_MODULE(pyqmap, m) {
       .def_readwrite("gates", &MappingResults::CircuitInfo::gates)
       .def_readwrite("single_qubit_gates",
                      &MappingResults::CircuitInfo::singleQubitGates)
-      .def_readwrite("cnots", &MappingResults::CircuitInfo::cnots)
+      .def_readwrite("two_qubit_gates",
+                     &MappingResults::CircuitInfo::twoQubitGates)
       .def_readwrite("layers", &MappingResults::CircuitInfo::layers)
       .def_readwrite("swaps", &MappingResults::CircuitInfo::swaps)
       .def_readwrite("direction_reverse",

--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -280,17 +280,17 @@ void Mapper::countGates(decltype(qcMapped.cbegin())      it,
       if (g->getType() == qc::SWAP) {
         if (architecture.bidirectional()) {
           info.gates += GATES_OF_BIDIRECTIONAL_SWAP;
-          info.cnots += GATES_OF_BIDIRECTIONAL_SWAP;
+          info.twoQubitGates += GATES_OF_BIDIRECTIONAL_SWAP;
         } else {
           info.gates += GATES_OF_UNIDIRECTIONAL_SWAP;
-          info.cnots += GATES_OF_BIDIRECTIONAL_SWAP;
+          info.twoQubitGates += GATES_OF_BIDIRECTIONAL_SWAP;
           info.singleQubitGates += GATES_OF_DIRECTION_REVERSE;
         }
       } else if (g->getControls().empty()) {
         ++info.singleQubitGates;
         ++info.gates;
       } else {
-        ++info.cnots;
+        ++info.twoQubitGates;
         ++info.gates;
       }
       continue;

--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -290,7 +290,6 @@ void Mapper::countGates(decltype(qcMapped.cbegin())      it,
         ++info.singleQubitGates;
         ++info.gates;
       } else {
-        assert(g->getType() == qc::X);
         ++info.cnots;
         ++info.gates;
       }

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -295,8 +295,11 @@ void ExactMapper::map(const Configuration& settings) {
           }
           qcMapped.h(reverse.first);
           qcMapped.h(reverse.second);
-          qcMapped.x(reverse.second,
-                     qc::Control{static_cast<qc::Qubit>(reverse.first)});
+          qcMapped.emplace_back<qc::StandardOperation>(
+              qcMapped.getNqubits(),
+              qc::Control{static_cast<qc::Qubit>(reverse.first)},
+              reverse.second, op->getType(), op->getParameter().at(0),
+              op->getParameter().at(1), op->getParameter().at(2));
           qcMapped.h(reverse.second);
           qcMapped.h(reverse.first);
         } else {
@@ -305,8 +308,11 @@ void ExactMapper::map(const Configuration& settings) {
                       << ": Added cnot with control and target: " << cnot.first
                       << " " << cnot.second << std::endl;
           }
-          qcMapped.x(cnot.second,
-                     qc::Control{static_cast<qc::Qubit>(cnot.first)});
+          qcMapped.emplace_back<qc::StandardOperation>(
+              qcMapped.getNqubits(),
+              qc::Control{static_cast<qc::Qubit>(cnot.first)}, cnot.second,
+              op->getType(), op->getParameter().at(0), op->getParameter().at(1),
+              op->getParameter().at(2));
         }
       }
     }

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -275,23 +275,24 @@ void ExactMapper::map(const Configuration& settings) {
             op->getParameter().at(0), op->getParameter().at(1),
             op->getParameter().at(2));
       } else {
-        const Edge cnot = {locations.at(static_cast<std::size_t>(gate.control)),
-                           locations.at(gate.target)};
+        const Edge controlledGate = {
+            locations.at(static_cast<std::size_t>(gate.control)),
+            locations.at(gate.target)};
 
-        if (architecture.getCouplingMap().find(cnot) ==
+        if (architecture.getCouplingMap().find(controlledGate) ==
             architecture.getCouplingMap().end()) {
-          const Edge reverse = {cnot.second, cnot.first};
+          const Edge reverse = {controlledGate.second, controlledGate.first};
           if (architecture.getCouplingMap().find(reverse) ==
               architecture.getCouplingMap().end()) {
-            throw QMAPException(
-                "Invalid CNOT: " + std::to_string(reverse.first) + "-" +
-                std::to_string(reverse.second));
+            throw QMAPException("Invalid controlled gate " + op->getName() +
+                                ": " + std::to_string(reverse.first) + "-" +
+                                std::to_string(reverse.second));
           }
           if (settings.verbose) {
-            std::cout
-                << i
-                << ": Added (direction-reversed) cnot with control and target: "
-                << cnot.first << " " << cnot.second << std::endl;
+            std::cout << i << ": Added (direction-reversed) controlled gate "
+                      << op->getName()
+                      << " with control and target: " << controlledGate.first
+                      << " " << controlledGate.second << std::endl;
           }
           qcMapped.h(reverse.first);
           qcMapped.h(reverse.second);
@@ -304,15 +305,15 @@ void ExactMapper::map(const Configuration& settings) {
           qcMapped.h(reverse.first);
         } else {
           if (settings.verbose) {
-            std::cout << i
-                      << ": Added cnot with control and target: " << cnot.first
-                      << " " << cnot.second << std::endl;
+            std::cout << i << ": Added controlled gate " << op->getName()
+                      << " with control and target: " << controlledGate.first
+                      << " " << controlledGate.second << std::endl;
           }
           qcMapped.emplace_back<qc::StandardOperation>(
               qcMapped.getNqubits(),
-              qc::Control{static_cast<qc::Qubit>(cnot.first)}, cnot.second,
-              op->getType(), op->getParameter().at(0), op->getParameter().at(1),
-              op->getParameter().at(2));
+              qc::Control{static_cast<qc::Qubit>(controlledGate.first)},
+              controlledGate.second, op->getType(), op->getParameter().at(0),
+              op->getParameter().at(1), op->getParameter().at(2));
         }
       }
     }

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -361,7 +361,7 @@ void ExactMapper::map(const Configuration& settings) {
 
   // 10) re-count gates
   results.output.singleQubitGates = 0U;
-  results.output.cnots            = 0U;
+  results.output.twoQubitGates    = 0U;
   results.output.gates            = 0U;
   countGates(qcMapped, results.output);
 
@@ -769,9 +769,9 @@ number of variables: (|L|-1) * m!
     // quickly determine cost
     choiceResults.output.singleQubitGates =
         choiceResults.input.singleQubitGates;
-    choiceResults.output.cnots = choiceResults.input.cnots;
-    choiceResults.output.gates =
-        choiceResults.output.singleQubitGates + choiceResults.output.cnots;
+    choiceResults.output.twoQubitGates = choiceResults.input.twoQubitGates;
+    choiceResults.output.gates         = choiceResults.output.singleQubitGates +
+                                 choiceResults.output.twoQubitGates;
     assert(choiceResults.output.swaps == 0U);
     assert(choiceResults.output.directionReverse == 0U);
     // swaps

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -94,17 +94,17 @@ void HeuristicMapper::map(const Configuration& configuration) {
           gateidx++;
         }
       } else {
-        const Edge cnot = {
+        const Edge controlledGate = {
             locations.at(static_cast<std::uint16_t>(gate.control)),
             locations.at(gate.target)};
-        if (architecture.getCouplingMap().find(cnot) ==
+        if (architecture.getCouplingMap().find(controlledGate) ==
             architecture.getCouplingMap().end()) {
-          const Edge reverse = {cnot.second, cnot.first};
+          const Edge reverse = {controlledGate.second, controlledGate.first};
           if (architecture.getCouplingMap().find(reverse) ==
               architecture.getCouplingMap().end()) {
-            throw QMAPException(
-                "Invalid CNOT: " + std::to_string(reverse.first) + "-" +
-                std::to_string(reverse.second));
+            throw QMAPException("Invalid controlled gate " + op->getName() +
+                                ": " + std::to_string(reverse.first) + "-" +
+                                std::to_string(reverse.second));
           }
           qcMapped.h(reverse.first);
           qcMapped.h(reverse.second);
@@ -121,9 +121,9 @@ void HeuristicMapper::map(const Configuration& configuration) {
         } else {
           qcMapped.emplace_back<qc::StandardOperation>(
               qcMapped.getNqubits(),
-              qc::Control{static_cast<qc::Qubit>(cnot.first)}, cnot.second,
-              op->getType(), op->getParameter().at(0), op->getParameter().at(1),
-              op->getParameter().at(2));
+              qc::Control{static_cast<qc::Qubit>(controlledGate.first)},
+              controlledGate.second, op->getType(), op->getParameter().at(0),
+              op->getParameter().at(1), op->getParameter().at(2));
           gateidx++;
         }
       }

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -108,16 +108,22 @@ void HeuristicMapper::map(const Configuration& configuration) {
           }
           qcMapped.h(reverse.first);
           qcMapped.h(reverse.second);
-          qcMapped.x(reverse.second,
-                     qc::Control{static_cast<qc::Qubit>(reverse.first)});
+          qcMapped.emplace_back<qc::StandardOperation>(
+              qcMapped.getNqubits(),
+              qc::Control{static_cast<qc::Qubit>(reverse.first)},
+              reverse.second, op->getType(), op->getParameter().at(0),
+              op->getParameter().at(1), op->getParameter().at(2));
           qcMapped.h(reverse.second);
           qcMapped.h(reverse.first);
 
           results.output.directionReverse++;
           gateidx += 5;
         } else {
-          qcMapped.x(cnot.second,
-                     qc::Control{static_cast<qc::Qubit>(cnot.first)});
+          qcMapped.emplace_back<qc::StandardOperation>(
+              qcMapped.getNqubits(),
+              qc::Control{static_cast<qc::Qubit>(cnot.first)}, cnot.second,
+              op->getType(), op->getParameter().at(0), op->getParameter().at(1),
+              op->getParameter().at(2));
           gateidx++;
         }
       }


### PR DESCRIPTION
## Description

These changes aim to better support arbitrary two qubit gates in the mapping process.
This is done by generalizing from cnot gates to any controlled gates:

1. Remove the assertion in countGates that ensures all controlled gates are cnot gates
1. When writing two qubit gates in the mapped circuit, use the operation type of the original circuit instead of always inserting cnot
1. Adjust messages and variable naming to reflect the change from cnot to arbitrary controlled gates

In bindings.cpp, I also renamed cnots to two_qubit_gates. I guess this would be a breaking change with python projects using qmap. I think the best course of action would be to keep both and mark cnots as deprecated.

Until qfr is updated some gates like controlled u gates will produce incorrect OpenQASM code resulting in Qiskit failing to read the mapped circuit and throwing exceptions in Python.

I'm not sure, if any further changes are required to support any two qubit gates, but I hope this serves as a good starting point.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
