### PR TITLE
Fix disjoint layer

### DIFF
--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -42,7 +42,6 @@ void Mapper::processDisjointQubitLayer(
     } else {
       layer = *lastLayer.at(target) + 1;
     }
-    lastLayer.at(target) = layer;
   } else {
     if (!lastLayer.at(*control).has_value() &&
         !lastLayer.at(target).has_value()) {
@@ -54,17 +53,20 @@ void Mapper::processDisjointQubitLayer(
     } else {
       layer = std::max(*lastLayer.at(*control), *lastLayer.at(target)) + 1;
     }
-    lastLayer.at(*control) = layer;
-    lastLayer.at(target)   = layer;
   }
 
   if (layers.size() <= layer) {
     layers.emplace_back();
+  } else {
+    layer = layers.size() - 1;
   }
   if (control.has_value()) {
     layers.back().emplace_back(*control, target, gate);
+    lastLayer.at(*control) = layer;
+    lastLayer.at(target)   = layer;
   } else {
     layers.back().emplace_back(-1, target, gate);
+    lastLayer.at(target) = layer;
   }
 }
 

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -155,6 +155,15 @@ TEST_P(HeuristicTest16Q, Dynamic) {
   SUCCEED() << "Mapping successful";
 }
 
+TEST_P(HeuristicTest16Q, Disjoint) {
+  Configuration settings{};
+  settings.layering = Layering::DisjointQubits;
+  ibmQX5Mapper->map(settings);
+  ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_dynamic.qasm");
+  ibmQX5Mapper->printResult(std::cout);
+  SUCCEED() << "Mapping successful";
+}
+
 class HeuristicTest20Q : public testing::TestWithParam<std::string> {
 protected:
   std::string testExampleDir      = "../examples/";


### PR DESCRIPTION
## Description

In the process of creating layers using the disjoint qubit strategy, multiple gates acting on the same qubit ended up in the same layer. As a result the heuristic mapping process ended up in an infinite looping searching for a possible mapping.

Problem:
When the previous gate was appended to a existing layer, the **lastLayer** variable was not updated correctly.

Fixes # (issue)
- fixed creation of disjoint layers

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
