### PR TITLE
Dijkstra node order bug fix

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -67,7 +67,7 @@ public:
 protected:
   static void dijkstra(const CouplingMap& couplingMap, std::vector<Node>& nodes,
                        std::uint16_t start);
-  
+
   struct NodeComparator {
     bool operator()(const Node* x, const Node* y) {
       if (x->cost != y->cost) {

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -67,6 +67,15 @@ public:
 protected:
   static void dijkstra(const CouplingMap& couplingMap, std::vector<Node>& nodes,
                        std::uint16_t start);
+  
+  struct NodeComparator {
+    bool operator()(const Node* x, const Node* y) {
+      if (x->cost != y->cost) {
+        return x->cost > y->cost;
+      }
+      return !x->containsCorrectEdge && y->containsCorrectEdge;
+    }
+  };
 };
 
 inline bool operator<(const Dijkstra::Node& x, const Dijkstra::Node& y) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -38,7 +38,7 @@ void Dijkstra::buildTable(const std::uint16_t n, const CouplingMap& couplingMap,
 
 void Dijkstra::dijkstra(const CouplingMap& couplingMap,
                         std::vector<Node>& nodes, std::uint16_t start) {
-  std::priority_queue<Node*> queue{};
+  std::priority_queue<Node*, std::vector<Node*>, NodeComparator> queue{};
   queue.push(&nodes.at(start));
   while (!queue.empty()) {
     auto* current    = queue.top();


### PR DESCRIPTION
## Description

The Dijkstra implementation in `utils.hpp` currently uses a priority queue of pointers, which therefore does a comparison of the pointers themselves instead of calling the < operator for the nodes when determining node order.
This is fixed in this pull request via a node comparator and initializing the priority queue with that.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
