### PR TITLE
fix disjoint qubit layering

### DIFF
--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -42,6 +42,7 @@ void Mapper::processDisjointQubitLayer(
     } else {
       layer = *lastLayer.at(target) + 1;
     }
+    lastLayer.at(target) = layer;
   } else {
     if (!lastLayer.at(*control).has_value() &&
         !lastLayer.at(target).has_value()) {
@@ -53,20 +54,17 @@ void Mapper::processDisjointQubitLayer(
     } else {
       layer = std::max(*lastLayer.at(*control), *lastLayer.at(target)) + 1;
     }
+    lastLayer.at(*control) = layer;
+    lastLayer.at(target)   = layer;
   }
 
   if (layers.size() <= layer) {
     layers.emplace_back();
-  } else {
-    layer = layers.size() - 1;
   }
   if (control.has_value()) {
-    layers.back().emplace_back(*control, target, gate);
-    lastLayer.at(*control) = layer;
-    lastLayer.at(target)   = layer;
+    layers.at(layer).emplace_back(*control, target, gate);
   } else {
-    layers.back().emplace_back(-1, target, gate);
-    lastLayer.at(target) = layer;
+    layers.at(layer).emplace_back(-1, target, gate);
   }
 }
 


### PR DESCRIPTION
## Description

Currently, the layering strategy `DisjointQubits` always inserts gates in the last layer. By instead inserting it one layer after the first layer (from the back of the circuit), in which it would intersect with the qubit set of a previous gate, we achieve a still valid layering with less layers. Visually speaking, we move each gate as far left as possible without intersecting other gates.

The following visualizations illustrate the status-quo and the new solution proposed in this PR on the following circuit:
![circuit_ordered](https://user-images.githubusercontent.com/15572450/221338578-3e66bd61-0e3c-466d-9227-53f4b43a56ac.png)
The numbers next to the gates indicate the gate order in the circuit.

Currently, the following layering strategy is implemented (red dots indicate the state of `laystLayer` for each qubit after inserting the gate):
![current](https://user-images.githubusercontent.com/15572450/221338498-8a1c785e-d9b6-4938-8e93-8445ea870636.png)

The proposed implementation:
![lukas](https://user-images.githubusercontent.com/15572450/221338519-bbe2b7aa-de98-4dc4-a6e2-effb25e60e16.png)

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
