### PR TITLE
Fix A* node ordering

### DIFF
--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -339,8 +339,10 @@ inline bool operator<(const HeuristicMapper::Node& x,
 
 inline bool operator>(const HeuristicMapper::Node& x,
                       const HeuristicMapper::Node& y) {
-  const auto xcost = static_cast<double>(x.costFixed) + x.lookaheadPenalty + x.costHeur;
-  const auto ycost = static_cast<double>(y.costFixed) + y.lookaheadPenalty + y.costHeur;
+  const auto xcost =
+      static_cast<double>(x.costFixed) + x.lookaheadPenalty + x.costHeur;
+  const auto ycost =
+      static_cast<double>(y.costFixed) + y.lookaheadPenalty + y.costHeur;
   if (std::abs(xcost - ycost) > 1e-6) {
     return xcost > ycost;
   }

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -339,8 +339,8 @@ inline bool operator<(const HeuristicMapper::Node& x,
 
 inline bool operator>(const HeuristicMapper::Node& x,
                       const HeuristicMapper::Node& y) {
-  const auto xcost = static_cast<double>(x.costFixed) + x.lookaheadPenalty;
-  const auto ycost = static_cast<double>(y.costFixed) + y.lookaheadPenalty;
+  const auto xcost = static_cast<double>(x.costFixed) + x.lookaheadPenalty + x.costHeur;
+  const auto ycost = static_cast<double>(y.costFixed) + y.lookaheadPenalty + y.costHeur;
   if (std::abs(xcost - ycost) > 1e-6) {
     return xcost > ycost;
   }


### PR DESCRIPTION
## Description

Fixing a small bug in the node ordering of A* search, in which the heuristic cost is only considered for nodes with different fixed cost + lookahead penalty

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
