### PR TITLE
🐛 Fixed bug in Clifford circuit tableau simulation

### DIFF
--- a/src/cliffordsynthesis/Tableau.cpp
+++ b/src/cliffordsynthesis/Tableau.cpp
@@ -258,10 +258,10 @@ void Tableau::applyCX(const std::size_t control, const std::size_t target) {
   assert(target < nQubits);
   assert(control != target);
   for (auto i = 0U; i < nQubits; ++i) {
-    const auto xa = tableau[i][target];
-    const auto za = tableau[i][target + nQubits];
-    const auto xb = tableau[i][control];
-    const auto zb = tableau[i][control + nQubits];
+    const auto xa = tableau[i][control];
+    const auto za = tableau[i][control + nQubits];
+    const auto xb = tableau[i][target];
+    const auto zb = tableau[i][target + nQubits];
     tableau[i][2 * nQubits] ^= (xa & zb) & ((xb ^ za) ^ 1);
     tableau[i][control + nQubits] = za ^ zb;
     tableau[i][target]            = xb ^ xa;

--- a/test/test_tableau.cpp
+++ b/test/test_tableau.cpp
@@ -323,4 +323,27 @@ TEST_F(TestTableau, TableauIO) {
   EXPECT_EQ(tableau, tableau2);
 }
 
+TEST_F(TestTableau, ApplyCXH) {
+  tableau = Tableau(3);
+  tableau.applyCX(1, 2);
+  std::string expected = "0;0;0;1;0;0;0\n0;0;0;0;1;0;0\n0;0;0;0;1;1;0";
+  EXPECT_EQ(tableau, Tableau(expected));
+  tableau.applyH(2);
+  expected = "0;0;0;1;0;0;0\n0;0;0;0;1;0;0\n0;0;1;0;1;0;0";
+  EXPECT_EQ(tableau, Tableau(expected));
+  tableau.applyH(1);
+  expected = "0;0;0;1;0;0;0\n0;1;0;0;0;0;0\n0;1;1;0;0;0;0";
+  EXPECT_EQ(tableau, Tableau(expected));
+  tableau.applyH(2);
+  expected = "0;0;0;1;0;0;0\n0;1;0;0;0;0;0\n0;1;0;0;0;1;0";
+  EXPECT_EQ(tableau, Tableau(expected));
+  tableau.applyCX(0, 2);
+  expected = "0;0;0;1;0;0;0\n0;1;0;0;0;0;0\n0;1;0;1;0;1;0";
+  EXPECT_EQ(tableau, Tableau(expected));
+  tableau.applyCX(0, 1);
+  expected = "0;0;0;1;0;0;0\n0;1;0;0;0;0;0\n0;1;0;1;0;1;0";
+  EXPECT_EQ(tableau, Tableau(expected));
+  EXPECT_EQ(tableau, Tableau("[+ZII, +IXI, +ZXZ]"));
+}
+
 } // namespace cs


### PR DESCRIPTION

## Description

In `applyCX` in the Tableau class the control and target qubits were incorrectly applied.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
