### PR TITLE
🐛 Fix performance regression in exact mapper on directed architectures

### DIFF
--- a/include/Architecture.hpp
+++ b/include/Architecture.hpp
@@ -15,6 +15,7 @@
 #include <map>
 #include <regex>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 constexpr std::uint8_t GATES_OF_BIDIRECTIONAL_SWAP  = 3U;
@@ -390,10 +391,10 @@ protected:
   static std::size_t findCouplingLimit(const CouplingMap& cm,
                                        std::uint16_t      nQubits);
   static std::size_t
-  findCouplingLimit(const CouplingMap& cm, std::uint16_t nQubits,
-                    const std::set<std::uint16_t>& qubitChoice);
-  static void
-  findCouplingLimit(std::uint16_t node, std::uint16_t curSum,
-                    const std::vector<std::vector<std::uint16_t>>& connections,
-                    std::vector<std::uint16_t>& d, std::vector<bool>& visited);
+              findCouplingLimit(const CouplingMap& cm, std::uint16_t nQubits,
+                                const std::set<std::uint16_t>& qubitChoice);
+  static void findCouplingLimit(
+      std::uint16_t node, std::uint16_t curSum,
+      const std::vector<std::unordered_set<std::uint16_t>>& connections,
+      std::vector<std::uint16_t>& d, std::vector<bool>& visited);
 };

--- a/include/configuration/Configuration.hpp
+++ b/include/configuration/Configuration.hpp
@@ -74,4 +74,7 @@ struct Configuration {
   [[nodiscard]] std::string    toString() const { return json().dump(2); }
 
   void setTimeout(const std::size_t sec) { timeout = sec; }
+  bool swapLimitsEnabled() const {
+    return (swapReduction != SwapReduction::None) && enableSwapLimits;
+  }
 };

--- a/include/configuration/Configuration.hpp
+++ b/include/configuration/Configuration.hpp
@@ -73,8 +73,8 @@ struct Configuration {
   [[nodiscard]] nlohmann::json json() const;
   [[nodiscard]] std::string    toString() const { return json().dump(2); }
 
-  void setTimeout(const std::size_t sec) { timeout = sec; }
-  bool swapLimitsEnabled() const {
+  void               setTimeout(const std::size_t sec) { timeout = sec; }
+  [[nodiscard]] bool swapLimitsEnabled() const {
     return (swapReduction != SwapReduction::None) && enableSwapLimits;
   }
 };

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -486,13 +486,15 @@ std::uint64_t Architecture::bfs(const std::uint16_t   start,
 
 std::size_t Architecture::findCouplingLimit(const CouplingMap&  cm,
                                             const std::uint16_t nQubits) {
-  std::vector<std::vector<std::uint16_t>> connections;
-  std::vector<std::uint16_t>              d;
-  std::vector<bool>                       visited;
+  std::vector<std::unordered_set<std::uint16_t>> connections;
+  std::vector<std::uint16_t>                     d;
+  std::vector<bool>                              visited;
   connections.resize(nQubits);
   std::uint16_t maxSum = 0;
   for (const auto& edge : cm) {
-    connections.at(edge.first).emplace_back(edge.second);
+    connections.at(edge.first).emplace(edge.second);
+    // make sure that the connections are bidirectional
+    connections.at(edge.second).emplace(edge.first);
   }
   for (std::uint16_t q = 0; q < nQubits; ++q) {
     d.clear();
@@ -513,15 +515,17 @@ std::size_t Architecture::findCouplingLimit(const CouplingMap&  cm,
 std::size_t Architecture::findCouplingLimit(const CouplingMap&  cm,
                                             const std::uint16_t nQubits,
                                             const QubitSubset&  qubitChoice) {
-  std::vector<std::vector<std::uint16_t>> connections;
-  std::vector<std::uint16_t>              d;
-  std::vector<bool>                       visited;
+  std::vector<std::unordered_set<std::uint16_t>> connections;
+  std::vector<std::uint16_t>                     d;
+  std::vector<bool>                              visited;
   connections.resize(nQubits);
   std::uint16_t maxSum = 0;
   for (const auto& edge : cm) {
     if ((qubitChoice.count(edge.first) != 0U) &&
         (qubitChoice.count(edge.second) != 0U)) {
-      connections.at(edge.first).emplace_back(edge.second);
+      connections.at(edge.first).emplace(edge.second);
+      // make sure that the connections are bidirectional
+      connections.at(edge.second).emplace(edge.first);
     }
   }
   for (std::uint16_t q = 0; q < nQubits; ++q) {
@@ -545,7 +549,7 @@ std::size_t Architecture::findCouplingLimit(const CouplingMap&  cm,
 
 void Architecture::findCouplingLimit(
     const std::uint16_t node, const std::uint16_t curSum,
-    const std::vector<std::vector<std::uint16_t>>& connections,
+    const std::vector<std::unordered_set<std::uint16_t>>& connections,
     std::vector<std::uint16_t>& d, std::vector<bool>& visited) {
   if (visited.at(node)) {
     return;

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -103,13 +103,13 @@ void ExactMapper::map(const Configuration& settings) {
     } else {
       maxLimit = architecture.getCouplingLimit() - 1U;
     }
-    if (!architecture.bidirectional()) {
-      // on a directed architecture, one more SWAP might be needed overall
-      // due to the directionality of the edges and direction reversal not
-      // being possible for every gate.
-      maxLimit += 1U;
-    }
     if (config.swapReduction == SwapReduction::CouplingLimit) {
+      if (!architecture.bidirectional()) {
+        // on a directed architecture, one more SWAP might be needed overall
+        // due to the directionality of the edges and direction reversal not
+        // being possible for every gate.
+        maxLimit += 1U;
+      }
       limit = maxLimit;
     } else if (config.swapReduction == SwapReduction::Increasing) {
       limit = 0U;

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -103,6 +103,12 @@ void ExactMapper::map(const Configuration& settings) {
     } else {
       maxLimit = architecture.getCouplingLimit() - 1U;
     }
+    if (!architecture.bidirectional()) {
+      // on a directed architecture, one more SWAP might be needed overall
+      // due to the directionality of the edges and direction reversal not
+      // being possible for every gate.
+      maxLimit += 1U;
+    }
     if (config.swapReduction == SwapReduction::CouplingLimit) {
       limit = maxLimit;
     } else if (config.swapReduction == SwapReduction::Increasing) {

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -407,7 +407,7 @@ void ExactMapper::coreMappingRoutine(
   //////////////////////////////////////////
   /// 	Check necessary permutations	//
   //////////////////////////////////////////
-  if (config.enableSwapLimits && !config.useBDD) {
+  if (config.swapLimitsEnabled() && !config.useBDD) {
     do {
       auto picost = architecture.minimumNumberOfSwaps(
           pi, static_cast<std::int64_t>(limit));
@@ -455,7 +455,7 @@ number of variables: (|L|-1) * m!
     y.emplace_back();
     piCount = 0;
     do {
-      if (skippedPi.count(piCount) == 0 || !config.enableSwapLimits) {
+      if (skippedPi.count(piCount) == 0 || !config.swapLimitsEnabled()) {
         yName.str("");
         yName << "y_" << k << '_' << piCount;
         y.back().emplace_back(lb->makeVariable(yName.str(), CType::BOOL));
@@ -627,7 +627,7 @@ number of variables: (|L|-1) * m!
     auto& i         = x[k - 1];
     auto& j         = x[k];
     do {
-      if (skippedPi.count(piCount) == 0 || !config.enableSwapLimits) {
+      if (skippedPi.count(piCount) == 0 || !config.swapLimitsEnabled()) {
         auto equal = LogicTerm(true);
         for (const auto qubit : qubitChoice) {
           for (std::size_t q = 0; q < qc.getNqubits(); ++q) {
@@ -651,7 +651,7 @@ number of variables: (|L|-1) * m!
       piCount         = 0;
       internalPiCount = 0;
       do {
-        if (skippedPi.count(piCount) == 0 || !config.enableSwapLimits) {
+        if (skippedPi.count(piCount) == 0 || !config.swapLimitsEnabled()) {
           onlyOne = onlyOne + LogicTerm::ite(y[k - 1][internalPiCount],
                                              LogicTerm(1), LogicTerm(0));
           ++internalPiCount;
@@ -666,7 +666,7 @@ number of variables: (|L|-1) * m!
       piCount         = 0;
       internalPiCount = 0;
       do {
-        if (skippedPi.count(piCount) == 0 || !config.enableSwapLimits) {
+        if (skippedPi.count(piCount) == 0 || !config.swapLimitsEnabled()) {
           varIDs.push_back(y[k - 1][internalPiCount]);
           ++internalPiCount;
         }
@@ -700,7 +700,7 @@ number of variables: (|L|-1) * m!
       reducedLayerIndices.size());
   auto cost = LogicTerm(0);
   do {
-    if (skippedPi.count(piCount) == 0 || !config.enableSwapLimits) {
+    if (skippedPi.count(piCount) == 0 || !config.swapLimitsEnabled()) {
       auto picost = architecture.minimumNumberOfSwaps(pi);
       if (architecture.bidirectional()) {
         picost *= GATES_OF_BIDIRECTIONAL_SWAP;
@@ -719,7 +719,7 @@ number of variables: (|L|-1) * m!
     }
     ++piCount;
   } while (std::next_permutation(pi.begin(), pi.end()));
-  if (config.enableSwapLimits && config.useBDD) {
+  if (config.swapLimitsEnabled() && config.useBDD) {
     for (std::size_t k = 1; k < reducedLayerIndices.size(); ++k) {
       lb->assertFormula(BuildBDD(weightedVars[k], y[k - 1],
                                  static_cast<int>(limit), lb.get()));
@@ -808,7 +808,7 @@ number of variables: (|L|-1) * m!
         // sort the permutation of the qubits to start fresh
         std::sort(pi.begin(), pi.end());
         do {
-          if (skippedPi.count(piCount) == 0 || !config.enableSwapLimits) {
+          if (skippedPi.count(piCount) == 0 || !config.swapLimitsEnabled()) {
             if (m->getBoolValue(y[k - 1][internalPiCount], lb.get())) {
               break;
             }

--- a/test/test_exact.cpp
+++ b/test/test_exact.cpp
@@ -534,7 +534,7 @@ TEST_F(ExactTest, Test4QCircuitThatUsesAll5Q) {
   EXPECT_EQ(results.output.swaps, 1);
 }
 
-TEST_F(ExactTest, Test) {
+TEST_F(ExactTest, RegressionTestDirectionReverseCost) {
   // Regression test for https://github.com/cda-tum/qmap/issues/251
   using namespace qc::literals;
 
@@ -557,7 +557,7 @@ TEST_F(ExactTest, Test) {
   EXPECT_EQ(mapper.getResults().output.directionReverse, 2);
 }
 
-TEST_F(ExactTest, Test2) {
+TEST_F(ExactTest, RegressionTestExactMapperPerformance) {
   // Regression test for https://github.com/cda-tum/qmap/issues/256
   std::stringstream ss{"OPENQASM 2.0;\n"
                        "include \"qelib1.inc\";\n"
@@ -596,4 +596,36 @@ TEST_F(ExactTest, Test2) {
   mapper2.map(settings);
   EXPECT_EQ(mapper2.getResults().output.swaps, 1);
   EXPECT_EQ(mapper2.getResults().output.directionReverse, 4);
+}
+
+TEST_F(ExactTest, RegressionTestExactMapperPerformance2) {
+  // Regression test for https://github.com/cda-tum/qmap/issues/256
+  std::stringstream ss{"OPENQASM 2.0;\n"
+                       "include \"qelib1.inc\";\n"
+                       "qreg q[4];\n"
+                       "cx q[0],q[1];\n"
+                       "cx q[3],q[0];\n"
+                       "cx q[1],q[3];\n"
+                       "cx q[1],q[0];\n"
+                       "cx q[3],q[0];\n"
+                       "cx q[1],q[3];\n"
+                       "cx q[0],q[1];\n"
+                       "cx q[1],q[2];\n"};
+
+  Architecture      arch;
+  const CouplingMap cm = {{1, 0}, {2, 0}, {2, 1}, {3, 2}, {3, 4}, {4, 2}};
+  arch.loadCouplingMap(5, cm);
+  qc.import(ss, qc::Format::OpenQASM);
+
+  auto mapper            = ExactMapper(qc, arch);
+  settings.swapReduction = SwapReduction::CouplingLimit;
+  mapper.map(settings);
+  EXPECT_EQ(mapper.getResults().output.swaps, 1);
+  EXPECT_EQ(mapper.getResults().output.directionReverse, 1);
+
+  auto mapper2           = ExactMapper(qc, arch);
+  settings.swapReduction = SwapReduction::None;
+  mapper2.map(settings);
+  EXPECT_EQ(mapper2.getResults().output.swaps, 1);
+  EXPECT_EQ(mapper2.getResults().output.directionReverse, 1);
 }

--- a/test/test_exact.cpp
+++ b/test/test_exact.cpp
@@ -583,7 +583,6 @@ TEST_F(ExactTest, Test2) {
   Architecture      arch;
   const CouplingMap cm = {{1, 0}, {2, 0}, {2, 1}, {3, 2}, {3, 4}, {4, 2}};
   arch.loadCouplingMap(5, cm);
-  arch.printCouplingMap(cm, std::cout);
   qc.import(ss, qc::Format::OpenQASM);
 
   auto mapper            = ExactMapper(qc, arch);


### PR DESCRIPTION
## Description

Fixes #256.
The underlying cause of the performance regression was an oversight in the addition of the SWAP limitation feature for the ASPDAC 2021 paper. The implementation did not properly handle directed architectures in various cases:
 - due to the unidirectional edges, the longest shortest path search would sometimes return paths that were too long. That alone wouldn't be a problem, but makes the performance suboptimal. This is fixed by making sure that the search for the longest shortest path considers edges in the coupling graph as bidirectional.
 - More critically, the coupling limit computation only computes the cost of moving any two qubits next to each other. However, in directed architectures, this might not be enough to make a two-qubit gate executable. The simplest case, where this can be seen is a directed two-qubit architecture and a circuit with two controlled-H gates that have flipped controls and targets. Obviously, a SWAP is required in that case, but the old coupling limit computation would result in a limit of zero. This is fixed by incrementing the coupling limit by one in case of directed architectures.
 - SWAP limits were activated even if `settings.swapReduction == SwapReduction::None`, which also led to the limit being set to zero. This was fixed by adjusting the condition for enabling swap reduction.
 - Last but not least, the solver optimization for directed architectures was not ideal and has been changed to using weighted clauses instead of separate minimisation calls.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
