### PR TITLE
Dijkstra arbitrary weights

### DIFF
--- a/include/Architecture.hpp
+++ b/include/Architecture.hpp
@@ -363,12 +363,8 @@ protected:
 
   void createDistanceTable();
   void createFidelityTable();
-  
-  static double dijkstraNodeToCostNonFidelityBidirectional(const Dijkstra::Node& node) {
-      return node.prevCost;
-  }
 
-  static double dijkstraNodeToCostNonFidelityUnidirectional(const Dijkstra::Node& node) {
+  static double dijkstraNodeToCostNonFidelity(const Dijkstra::Node& node) {
     // Dijkstra determines the minimal path cost from one physical qubit to 
     // another.  In the non-fidelity case we are only interested in swapping 2
     // logical qubits next to each other. Therefore the last swap cost has to 

--- a/include/Architecture.hpp
+++ b/include/Architecture.hpp
@@ -365,14 +365,15 @@ protected:
   void createFidelityTable();
 
   static double dijkstraNodeToCostNonFidelity(const Dijkstra::Node& node) {
-    // Dijkstra determines the minimal path cost from one physical qubit to 
+    // Dijkstra determines the minimal path cost from one physical qubit to
     // another.  In the non-fidelity case we are only interested in swapping 2
-    // logical qubits next to each other. Therefore the last swap cost has to 
-    // be ignored. That cost is stored in the field `node.prevCost` of each node.
+    // logical qubits next to each other. Therefore the last swap cost has to
+    // be ignored. That cost is stored in the field `node.prevCost` of each
+    // node.
     if (node.containsCorrectEdge) {
       return node.prevCost;
     } else {
-      // in case the last edge is a back-edge, we will need to reverse the CNOT, 
+      // in case the last edge is a back-edge, we will need to reverse the CNOT,
       // executed on that edge
       return node.prevCost + COST_DIRECTION_REVERSE;
     }

--- a/include/Architecture.hpp
+++ b/include/Architecture.hpp
@@ -363,22 +363,23 @@ protected:
 
   void createDistanceTable();
   void createFidelityTable();
-
-  static double costHeuristicBidirectional(const Dijkstra::Node& node) {
-    auto length = node.cost - 1;
-    if (node.containsCorrectEdge) {
-      return length * COST_BIDIRECTIONAL_SWAP;
-    }
-    throw QMAPException("In a bidrectional architecture it should not happen "
-                        "that a node does not contain the right edge.");
+  
+  static double dijkstraNodeToCostNonFidelityBidirectional(const Dijkstra::Node& node) {
+      return node.prevCost;
   }
 
-  static double costHeuristicUnidirectional(const Dijkstra::Node& node) {
-    auto length = node.cost - 1;
+  static double dijkstraNodeToCostNonFidelityUnidirectional(const Dijkstra::Node& node) {
+    // Dijkstra determines the minimal path cost from one physical qubit to 
+    // another.  In the non-fidelity case we are only interested in swapping 2
+    // logical qubits next to each other. Therefore the last swap cost has to 
+    // be ignored. That cost is stored in the field `node.prevCost` of each node.
     if (node.containsCorrectEdge) {
-      return length * COST_UNIDIRECTIONAL_SWAP;
+      return node.prevCost;
+    } else {
+      // in case the last edge is a back-edge, we will need to reverse the CNOT, 
+      // executed on that edge
+      return node.prevCost + COST_DIRECTION_REVERSE;
     }
-    return length * COST_UNIDIRECTIONAL_SWAP + COST_DIRECTION_REVERSE;
   }
 
   // added for teleportation

--- a/include/Architecture.hpp
+++ b/include/Architecture.hpp
@@ -372,11 +372,10 @@ protected:
     // node.
     if (node.containsCorrectEdge) {
       return node.prevCost;
-    } else {
-      // in case the last edge is a back-edge, we will need to reverse the CNOT,
-      // executed on that edge
-      return node.prevCost + COST_DIRECTION_REVERSE;
     }
+    // in case the last edge is a back-edge, we will need to reverse the CNOT,
+    // executed on that edge
+    return node.prevCost + COST_DIRECTION_REVERSE;
   }
 
   // added for teleportation

--- a/include/Architecture.hpp
+++ b/include/Architecture.hpp
@@ -364,7 +364,7 @@ protected:
   void createDistanceTable();
   void createFidelityTable();
 
-  static double dijkstraNodeToCostNonFidelity(const Dijkstra::Node& node) {
+  static double dijkstraNodeToCost(const Dijkstra::Node& node) {
     // Dijkstra determines the minimal path cost from one physical qubit to
     // another.  In the non-fidelity case we are only interested in swapping 2
     // logical qubits next to each other. Therefore the last swap cost has to

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -58,15 +58,16 @@ public:
     bool                         visited             = false;
     std::optional<std::uint16_t> pos                 = std::nullopt;
     double                       cost                = -1.;
+    double                       prevCost            = -1.;
   };
 
   static void buildTable(std::uint16_t n, const CouplingMap& couplingMap,
-                         Matrix& distanceTable,
+                         Matrix& distanceTable, const Matrix& edgeWeights,
                          const std::function<double(const Node&)>& cost);
 
 protected:
   static void dijkstra(const CouplingMap& couplingMap, std::vector<Node>& nodes,
-                       std::uint16_t start);
+                       std::uint16_t start, const Matrix& edgeWeights);
 
   struct NodeComparator {
     bool operator()(const Node* x, const Node* y) {

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -199,13 +199,8 @@ void Architecture::createDistanceTable() {
     }
   }
 
-  if (isBidirectional) {
-    Dijkstra::buildTable(nqubits, couplingMap, distanceTable, edgeWeights,
-                         Architecture::dijkstraNodeToCostNonFidelityBidirectional);
-  } else {
-    Dijkstra::buildTable(nqubits, couplingMap, distanceTable, edgeWeights,
-                         Architecture::dijkstraNodeToCostNonFidelityUnidirectional);
-  }
+  Dijkstra::buildTable(nqubits, couplingMap, distanceTable, edgeWeights,
+                      Architecture::dijkstraNodeToCostNonFidelity);
 }
 
 void Architecture::createFidelityTable() {

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -186,12 +186,11 @@ Architecture::Architecture(const std::uint16_t nQ, const CouplingMap& cm,
 
 void Architecture::createDistanceTable() {
   isBidirectional = true;
-  Matrix edgeWeights(
-      nqubits,
-      std::vector<double>(nqubits, std::numeric_limits<double>::max()));
+  Matrix edgeWeights(nqubits, std::vector<double>(
+                                  nqubits, std::numeric_limits<double>::max()));
   for (const auto& edge : couplingMap) {
     if (couplingMap.find({edge.second, edge.first}) == couplingMap.end()) {
-      isBidirectional = false;
+      isBidirectional                            = false;
       edgeWeights.at(edge.second).at(edge.first) = COST_UNIDIRECTIONAL_SWAP;
       edgeWeights.at(edge.first).at(edge.second) = COST_UNIDIRECTIONAL_SWAP;
     } else {
@@ -200,7 +199,7 @@ void Architecture::createDistanceTable() {
   }
 
   Dijkstra::buildTable(nqubits, couplingMap, distanceTable, edgeWeights,
-                      Architecture::dijkstraNodeToCostNonFidelity);
+                       Architecture::dijkstraNodeToCostNonFidelity);
 }
 
 void Architecture::createFidelityTable() {

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -185,19 +185,26 @@ Architecture::Architecture(const std::uint16_t nQ, const CouplingMap& cm,
 }
 
 void Architecture::createDistanceTable() {
+  isBidirectional = true;
+  Matrix edgeWeights(
+      nqubits,
+      std::vector<double>(nqubits, std::numeric_limits<double>::max()));
   for (const auto& edge : couplingMap) {
     if (couplingMap.find({edge.second, edge.first}) == couplingMap.end()) {
       isBidirectional = false;
-      break;
+      edgeWeights.at(edge.second).at(edge.first) = COST_UNIDIRECTIONAL_SWAP;
+      edgeWeights.at(edge.first).at(edge.second) = COST_UNIDIRECTIONAL_SWAP;
+    } else {
+      edgeWeights.at(edge.first).at(edge.second) = COST_BIDIRECTIONAL_SWAP;
     }
   }
 
   if (isBidirectional) {
-    Dijkstra::buildTable(nqubits, couplingMap, distanceTable,
-                         Architecture::costHeuristicBidirectional);
+    Dijkstra::buildTable(nqubits, couplingMap, distanceTable, edgeWeights,
+                         Architecture::dijkstraNodeToCostNonFidelityBidirectional);
   } else {
-    Dijkstra::buildTable(nqubits, couplingMap, distanceTable,
-                         Architecture::costHeuristicUnidirectional);
+    Dijkstra::buildTable(nqubits, couplingMap, distanceTable, edgeWeights,
+                         Architecture::dijkstraNodeToCostNonFidelityUnidirectional);
   }
 }
 

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -199,7 +199,7 @@ void Architecture::createDistanceTable() {
   }
 
   Dijkstra::buildTable(nqubits, couplingMap, distanceTable, edgeWeights,
-                       Architecture::dijkstraNodeToCostNonFidelity);
+                       Architecture::dijkstraNodeToCost);
 }
 
 void Architecture::createFidelityTable() {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -8,7 +8,7 @@
 #include <cassert>
 
 void Dijkstra::buildTable(const std::uint16_t n, const CouplingMap& couplingMap,
-                          Matrix& distanceTable,
+                          Matrix& distanceTable, const Matrix& edgeWeights,
                           const std::function<double(const Node&)>& cost) {
   distanceTable.clear();
   distanceTable.resize(n, std::vector<double>(n, -1.));
@@ -20,11 +20,13 @@ void Dijkstra::buildTable(const std::uint16_t n, const CouplingMap& couplingMap,
       nodes.at(j).visited             = false;
       nodes.at(j).pos                 = j;
       nodes.at(j).cost                = -1.;
+      nodes.at(j).prevCost            = -1.;
     }
 
-    nodes.at(i).cost = 0.;
+    nodes.at(i).cost     = 0.;
+    nodes.at(i).prevCost = 0.;
 
-    dijkstra(couplingMap, nodes, i);
+    dijkstra(couplingMap, nodes, i, edgeWeights);
 
     for (std::uint16_t j = 0; j < n; ++j) {
       if (i == j) {
@@ -37,7 +39,8 @@ void Dijkstra::buildTable(const std::uint16_t n, const CouplingMap& couplingMap,
 }
 
 void Dijkstra::dijkstra(const CouplingMap& couplingMap,
-                        std::vector<Node>& nodes, std::uint16_t start) {
+                        std::vector<Node>& nodes, std::uint16_t start,
+                        const Matrix& edgeWeights) {
   std::priority_queue<Node*, std::vector<Node*>, NodeComparator> queue{};
   queue.push(&nodes.at(start));
   while (!queue.empty()) {
@@ -61,8 +64,9 @@ void Dijkstra::dijkstra(const CouplingMap& couplingMap,
         }
 
         Node newNode;
-        newNode.cost                = current->cost + 1.0;
-        newNode.pos                 = to;
+        newNode.cost     = current->cost + edgeWeights.at(*pos).at(*to);
+        newNode.prevCost = current->cost;
+        newNode.pos      = to;
         newNode.containsCorrectEdge = correctEdge;
         if (nodes.at(*to).cost < 0 || newNode < nodes.at(*to)) {
           nodes.at(*to) = newNode;

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -63,7 +63,8 @@ TEST(General, Dijkstra) {
     (1)   (2)   (3)
   */
   CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 3}, {3, 2}, {1, 3}, {3, 1}};
-  Matrix edgeWeights = {{0, 1, 0, 0}, {1, 0, 2, 6}, {0, 15, 0, 3}, {0, 6, 3, 0}};
+  Matrix      edgeWeights = {
+      {0, 1, 0, 0}, {1, 0, 2, 6}, {0, 15, 0, 3}, {0, 6, 3, 0}};
   Matrix distanceTable{};
   Dijkstra::buildTable(4, cm, distanceTable, edgeWeights,
                        [](const Dijkstra::Node& n) { return n.cost; });

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -62,18 +62,22 @@ TEST(General, Dijkstra) {
   0 <-> 1 --> 2 <-> 3
     (1)   (2)   (3)
   */
- 
-  const CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 3}, {3, 2}, {1, 3}, {3, 1}};
-  
-  const Matrix edgeWeights = {{0, 1, 0, 0}, {1, 0, 2, 6}, {0, 15, 0, 3}, {0, 6, 3, 0}};
-  
-  const Matrix targetTable1 = {{0, 1, 3, 6}, {1, 0, 2, 5}, {10, 9, 0, 3}, {7, 6, 3, 0}};
+
+  const CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 3},
+                          {3, 2}, {1, 3}, {3, 1}};
+
+  const Matrix edgeWeights = {
+      {0, 1, 0, 0}, {1, 0, 2, 6}, {0, 15, 0, 3}, {0, 6, 3, 0}};
+
+  const Matrix targetTable1 = {
+      {0, 1, 3, 6}, {1, 0, 2, 5}, {10, 9, 0, 3}, {7, 6, 3, 0}};
   Matrix distanceTable{};
   Dijkstra::buildTable(4, cm, distanceTable, edgeWeights,
                        [](const Dijkstra::Node& n) { return n.cost; });
   EXPECT_EQ(distanceTable, targetTable1);
-  
-  const Matrix targetTable2 = {{0, 0, 1, 3}, {0, 0, 0, 2}, {9, 3, 0, 0}, {6, 0, 0, 0}};
+
+  const Matrix targetTable2 = {
+      {0, 0, 1, 3}, {0, 0, 0, 2}, {9, 3, 0, 0}, {6, 0, 0, 0}};
   distanceTable = {};
   Dijkstra::buildTable(4, cm, distanceTable, edgeWeights,
                        [](const Dijkstra::Node& n) { return n.prevCost; });

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -62,56 +62,20 @@ TEST(General, Dijkstra) {
   0 <-> 1 --> 2 <-> 3
     (1)   (2)   (3)
   */
-  CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 3}, {3, 2}, {1, 3}, {3, 1}};
-  Matrix      edgeWeights = {
-      {0, 1, 0, 0}, {1, 0, 2, 6}, {0, 15, 0, 3}, {0, 6, 3, 0}};
+ 
+  const CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 3}, {3, 2}, {1, 3}, {3, 1}};
+  
+  const Matrix edgeWeights = {{0, 1, 0, 0}, {1, 0, 2, 6}, {0, 15, 0, 3}, {0, 6, 3, 0}};
+  
+  const Matrix targetTable1 = {{0, 1, 3, 6}, {1, 0, 2, 5}, {10, 9, 0, 3}, {7, 6, 3, 0}};
   Matrix distanceTable{};
   Dijkstra::buildTable(4, cm, distanceTable, edgeWeights,
                        [](const Dijkstra::Node& n) { return n.cost; });
-  EXPECT_EQ(distanceTable.size(), 4);
-  EXPECT_EQ(distanceTable[0].size(), 4);
-  EXPECT_EQ(distanceTable[0][0], 0);
-  EXPECT_EQ(distanceTable[0][1], 1);
-  EXPECT_EQ(distanceTable[0][2], 3);
-  EXPECT_EQ(distanceTable[0][3], 6);
-  EXPECT_EQ(distanceTable[1].size(), 4);
-  EXPECT_EQ(distanceTable[1][0], 1);
-  EXPECT_EQ(distanceTable[1][1], 0);
-  EXPECT_EQ(distanceTable[1][2], 2);
-  EXPECT_EQ(distanceTable[1][3], 5);
-  EXPECT_EQ(distanceTable[2].size(), 4);
-  EXPECT_EQ(distanceTable[2][0], 10);
-  EXPECT_EQ(distanceTable[2][1], 9);
-  EXPECT_EQ(distanceTable[2][2], 0);
-  EXPECT_EQ(distanceTable[2][3], 3);
-  EXPECT_EQ(distanceTable[3].size(), 4);
-  EXPECT_EQ(distanceTable[3][0], 7);
-  EXPECT_EQ(distanceTable[3][1], 6);
-  EXPECT_EQ(distanceTable[3][2], 3);
-  EXPECT_EQ(distanceTable[3][3], 0);
-
+  EXPECT_EQ(distanceTable, targetTable1);
+  
+  const Matrix targetTable2 = {{0, 0, 1, 3}, {0, 0, 0, 2}, {9, 3, 0, 0}, {6, 0, 0, 0}};
   distanceTable = {};
   Dijkstra::buildTable(4, cm, distanceTable, edgeWeights,
                        [](const Dijkstra::Node& n) { return n.prevCost; });
-  EXPECT_EQ(distanceTable.size(), 4);
-  EXPECT_EQ(distanceTable[0].size(), 4);
-  EXPECT_EQ(distanceTable[0][0], 0);
-  EXPECT_EQ(distanceTable[0][1], 0);
-  EXPECT_EQ(distanceTable[0][2], 1);
-  EXPECT_EQ(distanceTable[0][3], 3);
-  EXPECT_EQ(distanceTable[1].size(), 4);
-  EXPECT_EQ(distanceTable[1][0], 0);
-  EXPECT_EQ(distanceTable[1][1], 0);
-  EXPECT_EQ(distanceTable[1][2], 0);
-  EXPECT_EQ(distanceTable[1][3], 2);
-  EXPECT_EQ(distanceTable[2].size(), 4);
-  EXPECT_EQ(distanceTable[2][0], 9);
-  EXPECT_EQ(distanceTable[2][1], 3);
-  EXPECT_EQ(distanceTable[2][2], 0);
-  EXPECT_EQ(distanceTable[2][3], 0);
-  EXPECT_EQ(distanceTable[3].size(), 4);
-  EXPECT_EQ(distanceTable[3][0], 6);
-  EXPECT_EQ(distanceTable[3][1], 0);
-  EXPECT_EQ(distanceTable[3][2], 0);
-  EXPECT_EQ(distanceTable[3][3], 0);
+  EXPECT_EQ(distanceTable, targetTable2);
 }

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -4,6 +4,7 @@
 //
 
 #include "Architecture.hpp"
+#include "utils.hpp"
 
 #include "gtest/gtest.h"
 #include <iostream>
@@ -51,4 +52,72 @@ TEST(General, TestLineParsing) {
 
   EXPECT_EQ(data[1], "Entry2");
   EXPECT_EQ(data[2], "EscapedEntry1;EscapedEntry2");
+}
+
+TEST(General, Dijkstra) {
+  /*
+            (6)
+        .----------.
+       \/          \/
+  0 <-> 1 --> 2 <-> 3
+    (1)   (2)   (3)
+  */
+  CouplingMap cm = {{0,1},{1,0},{1,2},{2,3},{3,2},{1,3},{3,1}};
+  Matrix edgeWeights = {
+    {0,1,0,0},
+    {1,0,2,6},
+    {0,15,0,3},
+    {0,6,3,0}
+  };
+  Matrix distanceTable{};
+  Dijkstra::buildTable(4, cm, distanceTable, edgeWeights, [](const Dijkstra::Node& n) {
+    return n.cost;
+  });
+  EXPECT_EQ(distanceTable.size(), 4);
+  EXPECT_EQ(distanceTable[0].size(), 4);
+  EXPECT_EQ(distanceTable[0][0], 0);
+  EXPECT_EQ(distanceTable[0][1], 1);
+  EXPECT_EQ(distanceTable[0][2], 3);
+  EXPECT_EQ(distanceTable[0][3], 6);
+  EXPECT_EQ(distanceTable[1].size(), 4);
+  EXPECT_EQ(distanceTable[1][0], 1);
+  EXPECT_EQ(distanceTable[1][1], 0);
+  EXPECT_EQ(distanceTable[1][2], 2);
+  EXPECT_EQ(distanceTable[1][3], 5);
+  EXPECT_EQ(distanceTable[2].size(), 4);
+  EXPECT_EQ(distanceTable[2][0], 10);
+  EXPECT_EQ(distanceTable[2][1], 9);
+  EXPECT_EQ(distanceTable[2][2], 0);
+  EXPECT_EQ(distanceTable[2][3], 3);
+  EXPECT_EQ(distanceTable[3].size(), 4);
+  EXPECT_EQ(distanceTable[3][0], 7);
+  EXPECT_EQ(distanceTable[3][1], 6);
+  EXPECT_EQ(distanceTable[3][2], 3);
+  EXPECT_EQ(distanceTable[3][3], 0);
+  
+  distanceTable = {};
+  Dijkstra::buildTable(4, cm, distanceTable, edgeWeights, [](const Dijkstra::Node& n) {
+    return n.prevCost;
+  });
+  EXPECT_EQ(distanceTable.size(), 4);
+  EXPECT_EQ(distanceTable[0].size(), 4);
+  EXPECT_EQ(distanceTable[0][0], 0);
+  EXPECT_EQ(distanceTable[0][1], 0);
+  EXPECT_EQ(distanceTable[0][2], 1);
+  EXPECT_EQ(distanceTable[0][3], 3);
+  EXPECT_EQ(distanceTable[1].size(), 4);
+  EXPECT_EQ(distanceTable[1][0], 0);
+  EXPECT_EQ(distanceTable[1][1], 0);
+  EXPECT_EQ(distanceTable[1][2], 0);
+  EXPECT_EQ(distanceTable[1][3], 2);
+  EXPECT_EQ(distanceTable[2].size(), 4);
+  EXPECT_EQ(distanceTable[2][0], 9);
+  EXPECT_EQ(distanceTable[2][1], 3);
+  EXPECT_EQ(distanceTable[2][2], 0);
+  EXPECT_EQ(distanceTable[2][3], 0);
+  EXPECT_EQ(distanceTable[3].size(), 4);
+  EXPECT_EQ(distanceTable[3][0], 6);
+  EXPECT_EQ(distanceTable[3][1], 0);
+  EXPECT_EQ(distanceTable[3][2], 0);
+  EXPECT_EQ(distanceTable[3][3], 0);
 }

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -63,8 +63,7 @@ TEST(General, Dijkstra) {
     (1)   (2)   (3)
   */
   CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 3}, {3, 2}, {1, 3}, {3, 1}};
-  Matrix      edgeWeights = {
-      {0, 1, 0, 0}, {1, 0, 2, 6}, {0, 15, 0, 3}, {0, 6, 3, 0}};
+  Matrix edgeWeights = {{0, 1, 0, 0}, {1, 0, 2, 6}, {0, 15, 0, 3}, {0, 6, 3, 0}};
   Matrix distanceTable{};
   Dijkstra::buildTable(4, cm, distanceTable, edgeWeights,
                        [](const Dijkstra::Node& n) { return n.cost; });

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -62,17 +62,12 @@ TEST(General, Dijkstra) {
   0 <-> 1 --> 2 <-> 3
     (1)   (2)   (3)
   */
-  CouplingMap cm = {{0,1},{1,0},{1,2},{2,3},{3,2},{1,3},{3,1}};
-  Matrix edgeWeights = {
-    {0,1,0,0},
-    {1,0,2,6},
-    {0,15,0,3},
-    {0,6,3,0}
-  };
+  CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 3}, {3, 2}, {1, 3}, {3, 1}};
+  Matrix      edgeWeights = {
+      {0, 1, 0, 0}, {1, 0, 2, 6}, {0, 15, 0, 3}, {0, 6, 3, 0}};
   Matrix distanceTable{};
-  Dijkstra::buildTable(4, cm, distanceTable, edgeWeights, [](const Dijkstra::Node& n) {
-    return n.cost;
-  });
+  Dijkstra::buildTable(4, cm, distanceTable, edgeWeights,
+                       [](const Dijkstra::Node& n) { return n.cost; });
   EXPECT_EQ(distanceTable.size(), 4);
   EXPECT_EQ(distanceTable[0].size(), 4);
   EXPECT_EQ(distanceTable[0][0], 0);
@@ -94,11 +89,10 @@ TEST(General, Dijkstra) {
   EXPECT_EQ(distanceTable[3][1], 6);
   EXPECT_EQ(distanceTable[3][2], 3);
   EXPECT_EQ(distanceTable[3][3], 0);
-  
+
   distanceTable = {};
-  Dijkstra::buildTable(4, cm, distanceTable, edgeWeights, [](const Dijkstra::Node& n) {
-    return n.prevCost;
-  });
+  Dijkstra::buildTable(4, cm, distanceTable, edgeWeights,
+                       [](const Dijkstra::Node& n) { return n.prevCost; });
   EXPECT_EQ(distanceTable.size(), 4);
   EXPECT_EQ(distanceTable[0].size(), 4);
   EXPECT_EQ(distanceTable[0][0], 0);


### PR DESCRIPTION
## Description

Replacing fixed edge costs in Dijkstra implementation with an edge weight matrix. Thereby enabling future expansions (fidelity-aware distances, semi-directional architectures, etc.)

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
