### PR TITLE
⬆️🪝 Update ruff and use automatic `target-version` inference

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
 
   # Run ruff (subsumes pyupgrade, isort, flake8+plugins, and more)
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.254
+    rev: v0.0.257
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/mqt/qmap/subarchitectures.py
+++ b/mqt/qmap/subarchitectures.py
@@ -48,7 +48,6 @@ class SubarchitectureOrder:
         self.__compute_subarchs()
         self.__compute_subarch_order()
         self.__compute_desirable_subarchitectures()
-        return
 
     @classmethod
     def from_retworkx_graph(cls, graph: rx.PyGraph) -> SubarchitectureOrder:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,7 +197,6 @@ ignore = [
     "PLR2004", # Magic values
     "PLR0913", # Too many arguments
 ]
-target-version = "py38"
 
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ class CMakeBuild(build_ext):
 
         version = get_version(root=".", relative_to=__file__)
 
-        extdir = str(Path(self.get_ext_fullpath(ext.name)).parent.resolve())  # type: ignore[no-untyped-call]
+        extdir = Path(self.get_ext_fullpath(ext.name)).parent.resolve()
 
         cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
         cfg = "Debug" if self.debug else "Release"

--- a/test/python/test_compile.py
+++ b/test/python/test_compile.py
@@ -43,7 +43,7 @@ def test_available_architectures_str(example_circuit: QuantumCircuit, arch: str)
     """Test that the available architectures can be properly used."""
     example_circuit_mapped, results = qmap.compile(example_circuit, arch=arch)
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
 
     result = verify(example_circuit, example_circuit_mapped)
     assert result.considered_equivalent() is True
@@ -67,7 +67,7 @@ def test_available_architectures_enum(example_circuit: QuantumCircuit, arch: qma
     """Test that the available architecture enums can be properly used."""
     example_circuit_mapped, results = qmap.compile(example_circuit, arch=arch)
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
 
     result = verify(example_circuit, example_circuit_mapped)
     assert result.considered_equivalent() is True
@@ -80,7 +80,7 @@ def test_architecture_from_file(example_circuit: QuantumCircuit) -> None:
 
     example_circuit_mapped, results = qmap.compile(example_circuit, arch="test_architecture.arch")
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
 
     result = verify(example_circuit, example_circuit_mapped)
     assert result.considered_equivalent() is True
@@ -91,7 +91,7 @@ def test_architecture_from_python(example_circuit: QuantumCircuit) -> None:
     arch = qmap.Architecture(3, {(0, 1), (0, 2), (1, 2)})
     example_circuit_mapped, results = qmap.compile(example_circuit, arch=arch)
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
 
     result = verify(example_circuit, example_circuit_mapped)
     assert result.considered_equivalent() is True
@@ -107,7 +107,7 @@ def test_calibration_from_file(example_circuit: QuantumCircuit) -> None:
 
     example_circuit_mapped, results = qmap.compile(example_circuit, arch=None, calibration="test_calibration.cal")
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
 
     result = verify(example_circuit, example_circuit_mapped)
     assert result.considered_equivalent() is True

--- a/test/python/test_exact_mapper.py
+++ b/test/python/test_exact_mapper.py
@@ -17,7 +17,7 @@ def test_exact_no_swaps_trivial_layout() -> None:
 
     qc_mapped, results = qmap.compile(qc, arch=FakeLondon(), method="exact")
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
     assert results.output.swaps == 0
 
     result = verify(qc, qc_mapped)
@@ -36,7 +36,7 @@ def test_exact_no_swaps_non_trivial_layout() -> None:
     qc_mapped, results = qmap.compile(qc, arch=FakeLondon(), method="exact")
 
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
     assert results.output.swaps == 0
 
     result = verify(qc, qc_mapped)
@@ -55,7 +55,7 @@ def test_exact_non_trivial_swaps() -> None:
     qc_mapped, results = qmap.compile(qc, arch=FakeLondon(), method="exact")
 
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
     assert results.output.swaps == 1
 
     result = verify(qc, qc_mapped)

--- a/test/python/test_heuristic_mapper.py
+++ b/test/python/test_heuristic_mapper.py
@@ -17,7 +17,7 @@ def test_heuristic_no_swaps_trivial_layout() -> None:
 
     qc_mapped, results = qmap.compile(qc, arch=FakeLondon())
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
     # assert results.output.swaps == 0
 
     result = verify(qc, qc_mapped)
@@ -36,7 +36,7 @@ def test_heuristic_no_swaps_non_trivial_layout() -> None:
     qc_mapped, results = qmap.compile(qc, arch=FakeLondon())
 
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
     # assert results.output.swaps == 0
 
     result = verify(qc, qc_mapped)
@@ -55,7 +55,7 @@ def test_heuristic_non_trivial_swaps() -> None:
     qc_mapped, results = qmap.compile(qc, arch=FakeLondon())
 
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
     assert results.output.swaps == 1
 
     print("\n")

--- a/test/python/test_qiskit_backend_imports.py
+++ b/test/python/test_qiskit_backend_imports.py
@@ -27,39 +27,39 @@ def test_old_backend_v1(example_circuit: QuantumCircuit) -> None:
     """Test that circuits can be mapped to Qiskit BackendV1 instances providing the old basis_gates."""
     _, results = qmap.compile(example_circuit, arch=FakeLondon())
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
 
 
 def test_old_backend_v2(example_circuit: QuantumCircuit) -> None:
     """Test that circuits can be mapped to Qiskit BackendV2 instances providing the old basis_gates."""
     _, results = qmap.compile(example_circuit, arch=FakeLondonV2())
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
 
 
 def test_new_backend_v1(example_circuit: QuantumCircuit) -> None:
     """Test that circuits can be mapped to Qiskit BackendV1 instances providing the new basis_gates."""
     _, results = qmap.compile(example_circuit, arch=FakeAthens())
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
 
 
 def test_new_backend_v2(example_circuit: QuantumCircuit) -> None:
     """Test that circuits can be mapped to Qiskit BackendV2 instances providing the new basis_gates."""
     _, results = qmap.compile(example_circuit, arch=FakeAthensV2())
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
 
 
 def test_architecture_from_v1_backend_properties(example_circuit: QuantumCircuit) -> None:
     """Test that circuits can be mapped by simply providing the backend properties (the BackendV1 way)."""
     _, results = qmap.compile(example_circuit, arch=None, calibration=FakeLondon().properties())
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit
 
 
 def test_architecture_from_v2_target(example_circuit: QuantumCircuit) -> None:
     """Test that circuits can be mapped by simply providing the target (the BackendV2 way)."""
     _, results = qmap.compile(example_circuit, arch=None, calibration=FakeLondonV2().target)
     assert results.timeout is False
-    assert results.mapped_circuit != ""
+    assert results.mapped_circuit


### PR DESCRIPTION
## Description

This small PR updates the configuration of the ruff pre-commit hook. Since `v0.255`, the `target-version` configuration property can be inferred directly, which allows to simplify the configuration.
It also fixes some newly introduced warnings.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
