### PR TITLE
🩹 change PyPI upload option to kebab-case

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,5 +92,5 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.pypi_password }}
-          skip_existing: true
+          skip-existing: true
           verbose: true


### PR DESCRIPTION
## Description

https://github.com/pypa/gh-action-pypi-publish changed the naming convention for action parameters from snake_case to kebab-case. While the old syntax will be supported until the next major version increase, a warning is admitted as of the latest version.
This PR changes the `skip_existing` option to `skip-existing` to reflect the above change and silence the warning.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
