### PR TITLE
♻️ Refactor heuristic mapper

### DIFF
--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -75,8 +75,8 @@ public:
     Node(const std::array<std::int16_t, MAX_DEVICE_QUBITS>& q,
          const std::array<std::int16_t, MAX_DEVICE_QUBITS>& loc,
          const std::vector<std::vector<Exchange>>&          sw            = {},
-         const double                                       initCostFixed = 0
-        ) : costFixed(initCostFixed) {
+         const double                                       initCostFixed = 0)
+        : costFixed(initCostFixed) {
       std::copy(q.begin(), q.end(), qubits.begin());
       std::copy(loc.begin(), loc.end(), locations.begin());
       std::copy(sw.begin(), sw.end(), std::back_inserter(swaps));
@@ -92,7 +92,9 @@ public:
     /**
      * @brief returns costFixed + lookaheadPenalty
      */
-    [[nodiscard]] double getTotalFixedCost() const { return costFixed + lookaheadPenalty; }
+    [[nodiscard]] double getTotalFixedCost() const {
+      return costFixed + lookaheadPenalty;
+    }
 
     /**
      * @brief applies an in-place swap of 2 qubits in `qubits` and `locations`

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-struct pairHash {
+struct PairHash {
   template <class T1, class T2>
   std::size_t operator()(const std::pair<T1, T2>& p) const {
     auto h1 = std::hash<T1>{}(p.first);

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -9,14 +9,14 @@
 #pragma once
 
 /**
- * number of two qubit gates acting on pairs of logical qubits in some layer
- * where the key entry corresponds to logical qubits pairs ({q1, q2}) and
- * the value entry to the number of gates acting on the pair in each direction
- * (the first number with control=q1, target=q2 and the second the reverse)
+ * number of two-qubit gates acting on pairs of logical qubits in some layer
+ * where the keys correspond to logical qubit pairs ({q1, q2}) and
+ * the values to the number of gates acting on a pair in each direction
+ * (the first number with control=q1, target=q2 and the second the reverse).
  *
- * e.g. with multiplicity {{0,1},{2,3}} there are 2 gates with logical
+ * e.g., with multiplicity {{0,1},{2,3}} there are 2 gates with logical
  * qubit 0 as control and qubit 1 as target, and 3 gates with 1 as control
- * and 0 as target
+ * and 0 as target.
  */
 using TwoQubitMultiplicity =
     std::map<Edge, std::pair<std::uint16_t, std::uint16_t>>;

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -38,7 +38,7 @@ public:
    * swaps, mappings and costs
    */
   struct Node {
-    /** current fixed cost (for non-fidelity-aware mapping all cost of all swaps already added) */
+    /** current fixed cost (for non-fidelity-aware mapping cost of all swaps already added) */
     double costFixed = 0;
     /** heuristic cost expected for future swaps needed in current circuit layer
      */

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -75,24 +75,24 @@ public:
     Node(const std::array<std::int16_t, MAX_DEVICE_QUBITS>& q,
          const std::array<std::int16_t, MAX_DEVICE_QUBITS>& loc,
          const std::vector<std::vector<Exchange>>&          sw            = {},
-         const double                                       initCostFixed = 0) {
+         const double                                       initCostFixed = 0
+        ) : costFixed(initCostFixed) {
       std::copy(q.begin(), q.end(), qubits.begin());
       std::copy(loc.begin(), loc.end(), locations.begin());
       std::copy(sw.begin(), sw.end(), std::back_inserter(swaps));
-      costFixed = initCostFixed;
     }
 
     /**
      * @brief returns costFixed + costHeur + lookaheadPenalty
      */
-    double getTotalCost() const {
+    [[nodiscard]] double getTotalCost() const {
       return costFixed + costHeur + lookaheadPenalty;
     }
 
     /**
      * @brief returns costFixed + lookaheadPenalty
      */
-    double getTotalFixedCost() const { return costFixed + lookaheadPenalty; }
+    [[nodiscard]] double getTotalFixedCost() const { return costFixed + lookaheadPenalty; }
 
     /**
      * @brief applies an in-place swap of 2 qubits in `qubits` and `locations`

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -9,16 +9,16 @@
 #pragma once
 
 struct pair_hash {
-    template <class T1, class T2>
-    std::size_t operator () (const std::pair<T1,T2> &p) const {
-        auto h1 = std::hash<T1>{}(p.first);
-        auto h2 = std::hash<T2>{}(p.second);
+  template <class T1, class T2>
+  std::size_t operator()(const std::pair<T1, T2>& p) const {
+    auto h1 = std::hash<T1>{}(p.first);
+    auto h2 = std::hash<T2>{}(p.second);
 
-        if constexpr (sizeof(size_t) >= 8) {
-          return h1 ^ (h2 + 0x517cc1b727220a95 + (h2 << 6) + (h2 >> 2));
-        }
-        return h1 ^ (h2 + 0x9e3779b9 + (h2 << 6) + (h2 >> 2));
+    if constexpr (sizeof(size_t) >= 8) {
+      return h1 ^ (h2 + 0x517cc1b727220a95 + (h2 << 6) + (h2 >> 2));
     }
+    return h1 ^ (h2 + 0x9e3779b9 + (h2 << 6) + (h2 >> 2));
+  }
 };
 
 /**
@@ -32,7 +32,8 @@ struct pair_hash {
  * and 0 as target.
  */
 using TwoQubitMultiplicity =
-    std::unordered_map<Edge, std::pair<std::uint16_t, std::uint16_t>, pair_hash>;
+    std::unordered_map<Edge, std::pair<std::uint16_t, std::uint16_t>,
+                       pair_hash>;
 
 class HeuristicMapper : public Mapper {
 public:
@@ -243,7 +244,7 @@ protected:
    * @param twoQubitGateMultiplicity number of two qubit gates acting on pairs
    * of logical qubits in the current layer
    */
-  void expandNode(const std::unordered_set<std::uint16_t>& consideredQubits, 
+  void expandNode(const std::unordered_set<std::uint16_t>& consideredQubits,
                   Node& node, std::size_t layer,
                   const TwoQubitMultiplicity& twoQubitGateMultiplicity);
 

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -32,7 +32,7 @@ struct PairHash {
  * and 0 as target.
  */
 using TwoQubitMultiplicity =
-    std::unordered_map<Edge, std::pair<std::uint16_t, std::uint16_t>, pairHash>;
+    std::unordered_map<Edge, std::pair<std::uint16_t, std::uint16_t>, PairHash>;
 
 class HeuristicMapper : public Mapper {
 public:

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -8,6 +8,19 @@
 
 #pragma once
 
+/**
+ * number of two qubit gates acting on pairs of logical qubits in some layer 
+ * where the key entry corresponds to logical qubits pairs ({q1, q2}) and
+ * the value entry to the number of gates acting on the pair in each direction 
+ * (the first number with conrol=q1, target=q2 and the second the reverse)
+ * 
+ * e.g. with multiplicity {{0,1},{2,3}} there are 2 gates with logical 
+ * qubit 0 as control and qubit 1 as target, and 3 gates with 1 as control 
+ * and 0 as target
+ */
+using TwoQubitMultiplicity =
+    std::map<Edge, std::pair<std::uint16_t, std::uint16_t>>;
+
 class HeuristicMapper : public Mapper {
 public:
   using Mapper::Mapper; // import constructors from parent class
@@ -25,8 +38,8 @@ public:
    * swaps, mappings and costs
    */
   struct Node {
-    /** cost of all swaps in the node */
-    std::uint64_t costFixed = 0;
+    /** current fixed cost (for non-fidelity-aware mapping all cost of all swaps already added) */
+    double costFixed = 0;
     /** heuristic cost expected for future swaps needed in current circuit layer
      */
     double costHeur = 0.;
@@ -60,98 +73,48 @@ public:
     Node() = default;
     Node(const std::array<std::int16_t, MAX_DEVICE_QUBITS>& q,
          const std::array<std::int16_t, MAX_DEVICE_QUBITS>& loc,
-         const std::vector<std::vector<Exchange>>&          sw = {}) {
+         const std::vector<std::vector<Exchange>>&          sw = {},
+         const double                                       initCostFixed = 0) {
       std::copy(q.begin(), q.end(), qubits.begin());
       std::copy(loc.begin(), loc.end(), locations.begin());
       std::copy(sw.begin(), sw.end(), std::back_inserter(swaps));
+      costFixed = initCostFixed;
+    }
+    
+    /**
+     * @brief returns costFixed + costHeur + lookaheadPenalty
+     */
+    double getTotalCost() const {
+      return costFixed + costHeur + lookaheadPenalty;
+    }
+
+    /**
+     * @brief returns costFixed + lookaheadPenalty
+     */
+    double getTotalFixedCost() const {
+      return costFixed + lookaheadPenalty;
     }
 
     /**
      * @brief applies an in-place swap of 2 qubits in `qubits` and `locations`
      * of the node
      */
-    void applySWAP(const Edge& swap, Architecture& arch) {
-      const auto q1 = qubits.at(swap.first);
-      const auto q2 = qubits.at(swap.second);
-
-      qubits.at(swap.first)  = q2;
-      qubits.at(swap.second) = q1;
-
-      if (q1 != -1) {
-        locations.at(static_cast<std::size_t>(q1)) =
-            static_cast<std::int16_t>(swap.second);
-      }
-      if (q2 != -1) {
-        locations.at(static_cast<std::size_t>(q2)) =
-            static_cast<std::int16_t>(swap.first);
-      }
-
-      if (arch.getCouplingMap().find(swap) != arch.getCouplingMap().end() ||
-          arch.getCouplingMap().find(Edge{swap.second, swap.first}) !=
-              arch.getCouplingMap().end()) {
-        swaps.back().emplace_back(swap.first, swap.second, qc::SWAP);
-      } else {
-        throw QMAPException("Something wrong in applySWAP.");
-      }
-    }
+    void applySWAP(const Edge& swap, Architecture& arch);
 
     /**
      * @brief applies an in-place teleportation of 2 qubits in `qubits` and
      * `locations` of the node
      */
-    void applyTeleportation(const Edge& swap, Architecture& arch) {
-      const auto q1 = qubits.at(swap.first);
-      const auto q2 = qubits.at(swap.second);
-
-      qubits.at(swap.first)  = q2;
-      qubits.at(swap.second) = q1;
-
-      if (q1 != -1) {
-        locations.at(static_cast<std::size_t>(q1)) =
-            static_cast<std::int16_t>(swap.second);
-      }
-      if (q2 != -1) {
-        locations.at(static_cast<std::size_t>(q2)) =
-            static_cast<std::int16_t>(swap.first);
-      }
-
-      std::uint16_t middleAnc = std::numeric_limits<decltype(middleAnc)>::max();
-      for (const auto& qpair : arch.getTeleportationQubits()) {
-        if (swap.first == qpair.first || swap.second == qpair.first) {
-          middleAnc = static_cast<std::uint16_t>(qpair.second);
-        } else if (swap.first == qpair.second || swap.second == qpair.second) {
-          middleAnc = static_cast<std::uint16_t>(qpair.first);
-        }
-      }
-
-      if (middleAnc == std::numeric_limits<decltype(middleAnc)>::max()) {
-        throw QMAPException("Teleportation between seemingly wrong qubits: " +
-                            std::to_string(swap.first) + " <--> " +
-                            std::to_string(swap.second));
-      }
-
-      std::uint16_t source = std::numeric_limits<decltype(source)>::max();
-      std::uint16_t target = std::numeric_limits<decltype(target)>::max();
-      if (arch.getCouplingMap().find({swap.first, middleAnc}) !=
-              arch.getCouplingMap().end() ||
-          arch.getCouplingMap().find({middleAnc, swap.first}) !=
-              arch.getCouplingMap().end()) {
-        source = swap.first;
-        target = swap.second;
-      } else {
-        source = swap.second;
-        target = swap.first;
-      }
-
-      if (source == middleAnc || target == middleAnc) {
-        std::clog << "FAIL: TELE " << source << " -(" << middleAnc << ")-> "
-                  << target << "\n";
-        throw QMAPException("Overlap between source/target and middle "
-                            "ancillary in teleportation.");
-      }
-
-      swaps.back().emplace_back(source, target, middleAnc, qc::Teleportation);
-    }
+    void applyTeleportation(const Edge& swap, Architecture& arch);
+    
+    /**
+     * @brief recalculates the fixed cost of the node from current mapping and
+     * swaps
+     *
+     * @param arch the architecture for calculating distances between physical
+     * qubits and supplying qubit information such as fidelity
+     */
+    void recalculateFixedCost(const Architecture& arch);
 
     /**
      * @brief calculates the heuristic cost of the current mapping in the node
@@ -160,41 +123,17 @@ public:
      * are mapped next to each other
      *
      * @param arch the architecture for calculating distances between physical
-     * qubits
-     * @param currentLayer a vector of all gates in the current layer
+     * qubits and supplying qubit information such as fidelity
+     * @param twoQubitGateMultiplicity number of two qubit gates acting on pairs 
+     * of logical qubits in the current layer
      * @param admissibleHeuristic controls if the heuristic should be calculated
      * such that it is admissible (i.e. A*-search should yield the optimal
      * solution using this heuristic)
-     * @param considerFidelity controls if the heuristic should consider
-     * fidelity data of the architecture
      */
-    void updateHeuristicCost(const Architecture&      arch,
-                             const std::vector<Gate>& currentLayer,
-                             bool                     admissibleHeuristic,
-                             [[maybe_unused]] bool    considerFidelity) {
-      costHeur = 0.;
-      done     = true;
-      for (const auto& gate : currentLayer) {
-        if (gate.singleQubit()) {
-          continue;
-        }
-
-        auto cost = arch.distance(
-            static_cast<std::uint16_t>(
-                locations.at(static_cast<std::uint16_t>(gate.control))),
-            static_cast<std::uint16_t>(locations.at(gate.target)));
-        auto fidelityCost = cost;
-        if (admissibleHeuristic) {
-          costHeur = std::max(costHeur, fidelityCost);
-        } else {
-          costHeur += fidelityCost;
-        }
-        if (cost > COST_DIRECTION_REVERSE) {
-          done = false;
-          return;
-        }
-      }
-    }
+    void updateHeuristicCost(
+        const Architecture&               arch,
+        const TwoQubitMultiplicity& twoQubitGateMultiplicity,
+        bool admissibleHeuristic);
 
     std::ostream& print(std::ostream& out) const {
       out << "{\n";
@@ -257,19 +196,14 @@ protected:
   virtual void mapToMinDistance(std::uint16_t source, std::uint16_t target);
 
   /**
-   * @brief gathers all qubits that are acted on by a 2-qubit-gate in the given
-   * layer in `consideredQubits`, and maps any of them that are not yet mapped
+   * @brief maps any yet unmapped qubits, which are acted on in a given layer,
    * to a physical qubit.
    *
-   * All gates are mapped in order of their index in the layer. The qubits are
-   * mapped to any 2 qubits with minimal distance on the architecture.
-   *
-   * @param layer index of the circuit layer to consider
-   * @param consideredQubits vector in which to gather all relevant qubits of
-   * this layer
+   * @param twoQubitGateMultiplicity number of two qubit gates acting on pairs 
+   * of logical qubits in the current layer
    */
-  virtual void mapUnmappedGates(std::size_t                 layer,
-                                std::vector<std::uint16_t>& consideredQubits);
+  virtual void mapUnmappedGates(
+    const TwoQubitMultiplicity& twoQubitGateMultiplicity);
 
   /**
    * @brief search for an optimal mapping/set of swaps using A*-search and the
@@ -292,9 +226,12 @@ protected:
    * 2-qubit-gate in the respective layer
    * @param node current search node
    * @param layer index of current circuit layer
+   * @param twoQubitGateMultiplicity number of two qubit gates acting on pairs 
+   * of logical qubits in the current layer
    */
-  void expandNode(const std::vector<std::uint16_t>& consideredQubits,
-                  Node& node, std::size_t layer);
+  void expandNode(const std::set<std::uint16_t>& consideredQubits, Node& node,
+                  std::size_t                    layer,
+                  const TwoQubitMultiplicity&    twoQubitGateMultiplicity);
 
   /**
    * @brief creates a new node with a swap on the given edge and adds it to
@@ -303,8 +240,12 @@ protected:
    * @param swap edge on which to perform a swap
    * @param node current search node
    * @param layer index of current circuit layer
+   * @param twoQubitGateMultiplicity number of two qubit gates acting on pairs 
+   * of logical qubits in the current layer
    */
-  void expandNodeAddOneSwap(const Edge& swap, Node& node, std::size_t layer);
+  void expandNodeAddOneSwap(
+      const Edge& swap, Node& node, std::size_t layer,
+      const TwoQubitMultiplicity& twoQubitGateMultiplicity);
 
   /**
    * @brief calculates the heuristic cost for the following layers and saves it
@@ -339,10 +280,8 @@ inline bool operator<(const HeuristicMapper::Node& x,
 
 inline bool operator>(const HeuristicMapper::Node& x,
                       const HeuristicMapper::Node& y) {
-  const auto xcost =
-      static_cast<double>(x.costFixed) + x.lookaheadPenalty + x.costHeur;
-  const auto ycost =
-      static_cast<double>(y.costFixed) + y.lookaheadPenalty + y.costHeur;
+  const auto xcost = x.getTotalCost();
+  const auto ycost = y.getTotalCost();
   if (std::abs(xcost - ycost) > 1e-6) {
     return xcost > ycost;
   }

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -8,19 +8,6 @@
 
 #pragma once
 
-struct PairHash {
-  template <class T1, class T2>
-  std::size_t operator()(const std::pair<T1, T2>& p) const {
-    auto h1 = std::hash<T1>{}(p.first);
-    auto h2 = std::hash<T2>{}(p.second);
-
-    if constexpr (sizeof(size_t) >= 8) {
-      return h1 ^ (h2 + 0x517cc1b727220a95 + (h2 << 6) + (h2 >> 2));
-    }
-    return h1 ^ (h2 + 0x9e3779b9 + (h2 << 6) + (h2 >> 2));
-  }
-};
-
 /**
  * number of two-qubit gates acting on pairs of logical qubits in some layer
  * where the keys correspond to logical qubit pairs ({q1, q2}, with q1<=q2)
@@ -32,7 +19,7 @@ struct PairHash {
  * and 0 as target.
  */
 using TwoQubitMultiplicity =
-    std::unordered_map<Edge, std::pair<std::uint16_t, std::uint16_t>, PairHash>;
+    std::map<Edge, std::pair<std::uint16_t, std::uint16_t>>;
 
 class HeuristicMapper : public Mapper {
 public:

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-struct pair_hash {
+struct pairHash {
   template <class T1, class T2>
   std::size_t operator()(const std::pair<T1, T2>& p) const {
     auto h1 = std::hash<T1>{}(p.first);
@@ -33,7 +33,7 @@ struct pair_hash {
  */
 using TwoQubitMultiplicity =
     std::unordered_map<Edge, std::pair<std::uint16_t, std::uint16_t>,
-                       pair_hash>;
+                       pairHash>;
 
 class HeuristicMapper : public Mapper {
 public:

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -12,7 +12,7 @@
  * number of two qubit gates acting on pairs of logical qubits in some layer
  * where the key entry corresponds to logical qubits pairs ({q1, q2}) and
  * the value entry to the number of gates acting on the pair in each direction
- * (the first number with conrol=q1, target=q2 and the second the reverse)
+ * (the first number with control=q1, target=q2 and the second the reverse)
  *
  * e.g. with multiplicity {{0,1},{2,3}} there are 2 gates with logical
  * qubit 0 as control and qubit 1 as target, and 3 gates with 1 as control

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -9,13 +9,13 @@
 #pragma once
 
 /**
- * number of two qubit gates acting on pairs of logical qubits in some layer 
+ * number of two qubit gates acting on pairs of logical qubits in some layer
  * where the key entry corresponds to logical qubits pairs ({q1, q2}) and
- * the value entry to the number of gates acting on the pair in each direction 
+ * the value entry to the number of gates acting on the pair in each direction
  * (the first number with conrol=q1, target=q2 and the second the reverse)
- * 
- * e.g. with multiplicity {{0,1},{2,3}} there are 2 gates with logical 
- * qubit 0 as control and qubit 1 as target, and 3 gates with 1 as control 
+ *
+ * e.g. with multiplicity {{0,1},{2,3}} there are 2 gates with logical
+ * qubit 0 as control and qubit 1 as target, and 3 gates with 1 as control
  * and 0 as target
  */
 using TwoQubitMultiplicity =
@@ -38,7 +38,8 @@ public:
    * swaps, mappings and costs
    */
   struct Node {
-    /** current fixed cost (for non-fidelity-aware mapping cost of all swaps already added) */
+    /** current fixed cost (for non-fidelity-aware mapping cost of all swaps
+     * already added) */
     double costFixed = 0;
     /** heuristic cost expected for future swaps needed in current circuit layer
      */
@@ -73,14 +74,14 @@ public:
     Node() = default;
     Node(const std::array<std::int16_t, MAX_DEVICE_QUBITS>& q,
          const std::array<std::int16_t, MAX_DEVICE_QUBITS>& loc,
-         const std::vector<std::vector<Exchange>>&          sw = {},
+         const std::vector<std::vector<Exchange>>&          sw            = {},
          const double                                       initCostFixed = 0) {
       std::copy(q.begin(), q.end(), qubits.begin());
       std::copy(loc.begin(), loc.end(), locations.begin());
       std::copy(sw.begin(), sw.end(), std::back_inserter(swaps));
       costFixed = initCostFixed;
     }
-    
+
     /**
      * @brief returns costFixed + costHeur + lookaheadPenalty
      */
@@ -91,9 +92,7 @@ public:
     /**
      * @brief returns costFixed + lookaheadPenalty
      */
-    double getTotalFixedCost() const {
-      return costFixed + lookaheadPenalty;
-    }
+    double getTotalFixedCost() const { return costFixed + lookaheadPenalty; }
 
     /**
      * @brief applies an in-place swap of 2 qubits in `qubits` and `locations`
@@ -106,7 +105,7 @@ public:
      * `locations` of the node
      */
     void applyTeleportation(const Edge& swap, Architecture& arch);
-    
+
     /**
      * @brief recalculates the fixed cost of the node from current mapping and
      * swaps
@@ -124,16 +123,16 @@ public:
      *
      * @param arch the architecture for calculating distances between physical
      * qubits and supplying qubit information such as fidelity
-     * @param twoQubitGateMultiplicity number of two qubit gates acting on pairs 
+     * @param twoQubitGateMultiplicity number of two qubit gates acting on pairs
      * of logical qubits in the current layer
      * @param admissibleHeuristic controls if the heuristic should be calculated
      * such that it is admissible (i.e. A*-search should yield the optimal
      * solution using this heuristic)
      */
-    void updateHeuristicCost(
-        const Architecture&               arch,
-        const TwoQubitMultiplicity& twoQubitGateMultiplicity,
-        bool admissibleHeuristic);
+    void
+    updateHeuristicCost(const Architecture&         arch,
+                        const TwoQubitMultiplicity& twoQubitGateMultiplicity,
+                        bool                        admissibleHeuristic);
 
     std::ostream& print(std::ostream& out) const {
       out << "{\n";
@@ -199,11 +198,11 @@ protected:
    * @brief maps any yet unmapped qubits, which are acted on in a given layer,
    * to a physical qubit.
    *
-   * @param twoQubitGateMultiplicity number of two qubit gates acting on pairs 
+   * @param twoQubitGateMultiplicity number of two qubit gates acting on pairs
    * of logical qubits in the current layer
    */
-  virtual void mapUnmappedGates(
-    const TwoQubitMultiplicity& twoQubitGateMultiplicity);
+  virtual void
+  mapUnmappedGates(const TwoQubitMultiplicity& twoQubitGateMultiplicity);
 
   /**
    * @brief search for an optimal mapping/set of swaps using A*-search and the
@@ -226,12 +225,12 @@ protected:
    * 2-qubit-gate in the respective layer
    * @param node current search node
    * @param layer index of current circuit layer
-   * @param twoQubitGateMultiplicity number of two qubit gates acting on pairs 
+   * @param twoQubitGateMultiplicity number of two qubit gates acting on pairs
    * of logical qubits in the current layer
    */
   void expandNode(const std::set<std::uint16_t>& consideredQubits, Node& node,
-                  std::size_t                    layer,
-                  const TwoQubitMultiplicity&    twoQubitGateMultiplicity);
+                  std::size_t                 layer,
+                  const TwoQubitMultiplicity& twoQubitGateMultiplicity);
 
   /**
    * @brief creates a new node with a swap on the given edge and adds it to
@@ -240,12 +239,12 @@ protected:
    * @param swap edge on which to perform a swap
    * @param node current search node
    * @param layer index of current circuit layer
-   * @param twoQubitGateMultiplicity number of two qubit gates acting on pairs 
+   * @param twoQubitGateMultiplicity number of two qubit gates acting on pairs
    * of logical qubits in the current layer
    */
-  void expandNodeAddOneSwap(
-      const Edge& swap, Node& node, std::size_t layer,
-      const TwoQubitMultiplicity& twoQubitGateMultiplicity);
+  void
+  expandNodeAddOneSwap(const Edge& swap, Node& node, std::size_t layer,
+                       const TwoQubitMultiplicity& twoQubitGateMultiplicity);
 
   /**
    * @brief calculates the heuristic cost for the following layers and saves it

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -53,9 +53,25 @@ void HeuristicMapper::map(const Configuration& configuration) {
       for (const auto& swaps : result.swaps) {
         for (const auto& swap : swaps) {
           if (swap.op == qc::SWAP) {
+            if (config.verbose) {
+              std::clog << "SWAP: " << swap.first << " <-> " << swap.second
+                        << "\n";
+            }
+            if (architecture.getCouplingMap().find({swap.first, swap.second}) ==
+                    architecture.getCouplingMap().end() &&
+                architecture.getCouplingMap().find({swap.second, swap.first}) ==
+                    architecture.getCouplingMap().end()) {
+              throw QMAPException(
+                  "Invalid SWAP: " + std::to_string(swap.first) + "<->" +
+                  std::to_string(swap.second));
+            }
             qcMapped.swap(swap.first, swap.second);
             results.output.swaps++;
           } else if (swap.op == qc::Teleportation) {
+            if (config.verbose) {
+              std::clog << "TELE: " << swap.first << " <-> " << swap.second
+                        << "\n";
+            }
             qcMapped.emplace_back<qc::StandardOperation>(
                 qcMapped.getNqubits(),
                 qc::Targets{static_cast<qc::Qubit>(swap.first),
@@ -301,21 +317,16 @@ void HeuristicMapper::createInitialMapping() {
 }
 
 void HeuristicMapper::mapUnmappedGates(
-    std::size_t layer, std::vector<std::uint16_t>& consideredQubits) {
-  for (const auto& gate : layers.at(layer)) {
-    if (gate.singleQubit()) {
-      continue;
-    }
+    const TwoQubitMultiplicity& twoQubitGateMultiplicity) {
+  
+  for (const auto& edgeMultiplicity : twoQubitGateMultiplicity) {
+    auto q1 = edgeMultiplicity.first.first;
+    auto q2 = edgeMultiplicity.first.second;
 
-    consideredQubits.push_back(static_cast<std::uint16_t>(gate.control));
-    consideredQubits.push_back(gate.target);
+    auto q1Location = locations.at(q1);
+    auto q2Location = locations.at(q2);
 
-    auto controlLocation =
-        locations.at(static_cast<std::uint16_t>(gate.control));
-    auto targetLocation = locations.at(gate.target);
-
-    if (controlLocation == DEFAULT_POSITION &&
-        targetLocation == DEFAULT_POSITION) {
+    if (q1Location == DEFAULT_POSITION && q2Location == DEFAULT_POSITION) {
       std::set<Edge> possibleEdges{};
       // gather all edges in the architecture for which both qubits are unmapped
       for (const auto& edge : architecture.getCouplingMap()) {
@@ -347,27 +358,22 @@ void HeuristicMapper::mapUnmappedGates(
       }
       // TODO: Consider fidelity here if available. The best available edge
       // should be chosen
-      locations.at(static_cast<std::size_t>(gate.control)) =
-          static_cast<std::int16_t>(chosenEdge.first);
-      locations.at(gate.target) = static_cast<std::int16_t>(chosenEdge.second);
-      qubits.at(chosenEdge.first)  = gate.control;
-      qubits.at(chosenEdge.second) = static_cast<std::int16_t>(gate.target);
-      qc::QuantumComputation::findAndSWAP(static_cast<qc::Qubit>(gate.control),
-                                          chosenEdge.first,
+      locations.at(q1) = static_cast<std::int16_t>(chosenEdge.first);
+      locations.at(q2) = static_cast<std::int16_t>(chosenEdge.second);
+      qubits.at(chosenEdge.first)  = static_cast<std::int16_t>(q1);
+      qubits.at(chosenEdge.second) = static_cast<std::int16_t>(q2);
+      qc::QuantumComputation::findAndSWAP(q1, chosenEdge.first,
                                           qcMapped.initialLayout);
-      qc::QuantumComputation::findAndSWAP(static_cast<qc::Qubit>(gate.target),
-                                          chosenEdge.second,
+      qc::QuantumComputation::findAndSWAP(q2, chosenEdge.second,
                                           qcMapped.initialLayout);
-      qc::QuantumComputation::findAndSWAP(static_cast<qc::Qubit>(gate.control),
-                                          chosenEdge.first,
+      qc::QuantumComputation::findAndSWAP(q1, chosenEdge.first,
                                           qcMapped.outputPermutation);
-      qc::QuantumComputation::findAndSWAP(static_cast<qc::Qubit>(gate.target),
-                                          chosenEdge.second,
+      qc::QuantumComputation::findAndSWAP(q2, chosenEdge.second,
                                           qcMapped.outputPermutation);
-    } else if (controlLocation == DEFAULT_POSITION) {
-      mapToMinDistance(gate.target, static_cast<std::uint16_t>(gate.control));
-    } else if (targetLocation == DEFAULT_POSITION) {
-      mapToMinDistance(static_cast<std::uint16_t>(gate.control), gate.target);
+    } else if (q1Location == DEFAULT_POSITION) {
+      mapToMinDistance(q2, q1);
+    } else if (q2Location == DEFAULT_POSITION) {
+      mapToMinDistance(q1, q2);
     }
   }
 }
@@ -395,23 +401,47 @@ void HeuristicMapper::mapToMinDistance(const std::uint16_t source,
 }
 
 HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
-  std::vector<std::uint16_t> consideredQubits{};
-  Node                       node{};
+  std::set<std::uint16_t> consideredQubits{};
+  Node                    node{};
+  TwoQubitMultiplicity    twoQubitGateMultiplicity{};
+  
+  for (const auto& gate : layers.at(layer)) {
+    if (!gate.singleQubit()) {
+      const bool  reverse = gate.control >= gate.target;
+      const auto& q1 =
+          reverse ? gate.target : static_cast<std::uint16_t>(gate.control);
+      const auto& q2 =
+          reverse ? static_cast<std::uint16_t>(gate.control) : gate.target;
+      consideredQubits.emplace(q1);
+      consideredQubits.emplace(q2);
+      if (twoQubitGateMultiplicity.find({q1, q2}) ==
+          twoQubitGateMultiplicity.end()) {
+        twoQubitGateMultiplicity[{q1, q2}] = {!reverse, reverse};
+      } else {
+        if (reverse) {
+          twoQubitGateMultiplicity[{q1, q2}].second++;
+        } else {
+          twoQubitGateMultiplicity[{q1, q2}].first++;
+        }
+      }
+    }
+  }
 
-  mapUnmappedGates(layer, consideredQubits);
+  mapUnmappedGates(twoQubitGateMultiplicity);
 
   node.locations = locations;
   node.qubits    = qubits;
-  node.updateHeuristicCost(architecture, layers.at(layer),
-                           results.config.admissibleHeuristic,
-                           results.config.considerFidelity);
+  node.recalculateFixedCost(architecture);
+  node.updateHeuristicCost(
+      architecture, twoQubitGateMultiplicity,
+      results.config.admissibleHeuristic);
 
   nodes.push(node);
 
   while (!nodes.top().done) {
     Node current = nodes.top();
     nodes.pop();
-    expandNode(consideredQubits, current, layer);
+    expandNode(consideredQubits, current, layer, twoQubitGateMultiplicity);
   }
 
   Node result = nodes.top();
@@ -426,8 +456,9 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
 }
 
 void HeuristicMapper::expandNode(
-    const std::vector<std::uint16_t>& consideredQubits, Node& node,
-    std::size_t layer) {
+    const std::set<std::uint16_t>& consideredQubits, Node& node,
+    std::size_t layer,
+    const TwoQubitMultiplicity&    twoQubitGateMultiplicity) {
   std::vector<std::vector<bool>> usedSwaps;
   usedSwaps.reserve(architecture.getNqubits());
   for (int p = 0; p < architecture.getNqubits(); ++p) {
@@ -486,48 +517,39 @@ void HeuristicMapper::expandNode(
         auto q1 = node.qubits.at(edge.first);
         auto q2 = node.qubits.at(edge.second);
         if (q2 == -1 || q1 == -1) {
-          expandNodeAddOneSwap(edge, node, layer);
+          expandNodeAddOneSwap(edge, node, layer, twoQubitGateMultiplicity);
         } else if (!usedSwaps.at(static_cast<std::size_t>(q1))
                         .at(static_cast<std::size_t>(q2))) {
           usedSwaps.at(static_cast<std::size_t>(q1))
               .at(static_cast<std::size_t>(q2)) = true;
           usedSwaps.at(static_cast<std::size_t>(q2))
               .at(static_cast<std::size_t>(q1)) = true;
-          expandNodeAddOneSwap(edge, node, layer);
+          expandNodeAddOneSwap(edge, node, layer, twoQubitGateMultiplicity);
         }
       }
     }
   }
 }
 
-void HeuristicMapper::expandNodeAddOneSwap(const Edge& swap, Node& node,
-                                           const std::size_t layer) {
+void HeuristicMapper::expandNodeAddOneSwap(
+    const Edge& swap, Node& node, const std::size_t layer,
+    const TwoQubitMultiplicity&    twoQubitGateMultiplicity) {
   const auto& config       = results.config;
-  auto&       currentLayer = layers.at(layer);
 
-  Node newNode = Node(node.qubits, node.locations, node.swaps);
-  newNode.nswaps++;
-
-  newNode.swaps.emplace_back();
+  Node newNode = Node(node.qubits, node.locations, node.swaps, node.costFixed);
+  
   if (architecture.getCouplingMap().find(swap) !=
           architecture.getCouplingMap().end() ||
       architecture.getCouplingMap().find(Edge{swap.second, swap.first}) !=
           architecture.getCouplingMap().end()) {
-    if (architecture.bidirectional()) {
-      newNode.costFixed = node.costFixed + COST_BIDIRECTIONAL_SWAP;
-    } else {
-      newNode.costFixed = node.costFixed + COST_UNIDIRECTIONAL_SWAP;
-    }
-
     newNode.applySWAP(swap, architecture);
   } else {
-    newNode.costFixed = node.costFixed + COST_TELEPORTATION;
     newNode.applyTeleportation(swap, architecture);
   }
 
-  newNode.updateHeuristicCost(architecture, currentLayer,
-                              results.config.admissibleHeuristic,
-                              results.config.considerFidelity);
+  newNode.updateHeuristicCost(architecture,
+                              twoQubitGateMultiplicity,
+                              results.config.admissibleHeuristic);
 
   // calculate heuristics for the cost of the following layers
   if (config.lookahead) {
@@ -595,5 +617,166 @@ void HeuristicMapper::lookahead(const std::size_t      layer,
     factor *= config.lookaheadFactor;
     nextLayer = getNextLayer(nextLayer); // TODO: consider single qubits here
                                          // for better fidelity lookahead
+  }
+}
+
+
+void HeuristicMapper::Node::applySWAP(
+    const Edge& swap, Architecture& arch) {
+  nswaps++;
+  swaps.emplace_back();
+  const auto q1 = qubits.at(swap.first);
+  const auto q2 = qubits.at(swap.second);
+
+  qubits.at(swap.first)  = q2;
+  qubits.at(swap.second) = q1;
+
+  if (q1 != -1) {
+    locations.at(static_cast<std::size_t>(q1)) =
+        static_cast<std::int16_t>(swap.second);
+  }
+  if (q2 != -1) {
+    locations.at(static_cast<std::size_t>(q2)) =
+        static_cast<std::int16_t>(swap.first);
+  }
+
+  if (arch.getCouplingMap().find(swap) != arch.getCouplingMap().end() ||
+      arch.getCouplingMap().find(Edge{swap.second, swap.first}) !=
+          arch.getCouplingMap().end()) {
+    swaps.back().emplace_back(swap.first, swap.second, qc::SWAP);
+  } else {
+    throw QMAPException("Something wrong in applySWAP.");
+  }
+
+  if (arch.bidirectional()) {
+    costFixed += COST_BIDIRECTIONAL_SWAP;
+  } else {
+    costFixed += COST_UNIDIRECTIONAL_SWAP;
+  }
+}
+
+void HeuristicMapper::Node::applyTeleportation(const Edge&   swap,
+                                               Architecture& arch) {
+  nswaps++;
+  swaps.emplace_back();
+  const auto q1 = qubits.at(swap.first);
+  const auto q2 = qubits.at(swap.second);
+
+  qubits.at(swap.first)  = q2;
+  qubits.at(swap.second) = q1;
+
+  if (q1 != -1) {
+    locations.at(static_cast<std::size_t>(q1)) =
+        static_cast<std::int16_t>(swap.second);
+  }
+  if (q2 != -1) {
+    locations.at(static_cast<std::size_t>(q2)) =
+        static_cast<std::int16_t>(swap.first);
+  }
+
+  std::uint16_t middleAnc = std::numeric_limits<decltype(middleAnc)>::max();
+  for (const auto& qpair : arch.getTeleportationQubits()) {
+    if (swap.first == qpair.first || swap.second == qpair.first) {
+      middleAnc = static_cast<std::uint16_t>(qpair.second);
+    } else if (swap.first == qpair.second || swap.second == qpair.second) {
+      middleAnc = static_cast<std::uint16_t>(qpair.first);
+    }
+  }
+
+  if (middleAnc == std::numeric_limits<decltype(middleAnc)>::max()) {
+    throw QMAPException("Teleportation between seemingly wrong qubits: " +
+                        std::to_string(swap.first) + " <--> " +
+                        std::to_string(swap.second));
+  }
+
+  std::uint16_t source = std::numeric_limits<decltype(source)>::max();
+  std::uint16_t target = std::numeric_limits<decltype(target)>::max();
+  if (arch.getCouplingMap().find({swap.first, middleAnc}) !=
+          arch.getCouplingMap().end() ||
+      arch.getCouplingMap().find({middleAnc, swap.first}) !=
+          arch.getCouplingMap().end()) {
+    source = swap.first;
+    target = swap.second;
+  } else {
+    source = swap.second;
+    target = swap.first;
+  }
+
+  if (source == middleAnc || target == middleAnc) {
+    std::clog << "FAIL: TELE " << source << " -(" << middleAnc << ")-> "
+              << target << "\n";
+    throw QMAPException("Overlap between source/target and middle "
+                        "ancillary in teleportation.");
+  }
+
+  swaps.back().emplace_back(source, target, middleAnc, qc::Teleportation);
+
+  costFixed += COST_TELEPORTATION;
+}
+
+void HeuristicMapper::Node::recalculateFixedCost(const Architecture& arch) {
+  costFixed = 0;
+  for (auto& swapNode : swaps) {
+    for (auto& swap : swapNode) {
+      if (swap.op == qc::SWAP) {
+        if (arch.bidirectional()) {
+          costFixed += COST_BIDIRECTIONAL_SWAP;
+        } else {
+          costFixed += COST_UNIDIRECTIONAL_SWAP;
+        }
+      } else if (swap.op == qc::Teleportation) {
+        costFixed += COST_TELEPORTATION;
+      }
+    }
+  }
+}
+
+void HeuristicMapper::Node::updateHeuristicCost(
+    const Architecture&         arch, 
+    const TwoQubitMultiplicity& twoQubitGateMultiplicity, 
+    bool                        admissibleHeuristic) {
+  costHeur = 0.;
+  done     = true;
+
+  // iterating over all virtual qubit pairs, that share a gate on the
+  // current layer
+  for (const auto& edgeMultiplicity : twoQubitGateMultiplicity) {
+    const auto& q1                   = edgeMultiplicity.first.first;
+    const auto& q2                   = edgeMultiplicity.first.second;
+    const auto& straightMultiplicity = edgeMultiplicity.second.first;
+    const auto& reverseMultiplicity  = edgeMultiplicity.second.second;
+
+    bool edgeDone = (arch.getCouplingMap().find(
+                         {static_cast<std::uint16_t>(locations.at(q1)),
+                          static_cast<std::uint16_t>(locations.at(q2))}) !=
+                         arch.getCouplingMap().end() ||
+                     arch.getCouplingMap().find(
+                         {static_cast<std::uint16_t>(locations.at(q2)),
+                          static_cast<std::uint16_t>(locations.at(q1))}) !=
+                         arch.getCouplingMap().end());
+    // only if all qubit pairs are mapped next to each other the mapping
+    // is complete
+    if (!edgeDone) {
+      done = false;
+    }
+    
+    double swapCostStraight =
+        arch.distance(static_cast<std::uint16_t>(locations.at(q1)),
+                      static_cast<std::uint16_t>(locations.at(q2)));
+    double swapCostReverse =
+        arch.distance(static_cast<std::uint16_t>(locations.at(q2)),
+                      static_cast<std::uint16_t>(locations.at(q1)));
+
+    if (admissibleHeuristic) {
+      if (straightMultiplicity > 0) {
+        costHeur = std::max(costHeur, swapCostStraight);
+      }
+      if (reverseMultiplicity > 0) {
+        costHeur = std::max(costHeur, swapCostReverse);
+      }
+    } else {
+      costHeur += swapCostStraight * straightMultiplicity +
+                  swapCostReverse * reverseMultiplicity;
+    }
   }
 }

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -318,7 +318,6 @@ void HeuristicMapper::createInitialMapping() {
 
 void HeuristicMapper::mapUnmappedGates(
     const TwoQubitMultiplicity& twoQubitGateMultiplicity) {
-  
   for (const auto& edgeMultiplicity : twoQubitGateMultiplicity) {
     auto q1 = edgeMultiplicity.first.first;
     auto q2 = edgeMultiplicity.first.second;
@@ -404,7 +403,7 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
   std::set<std::uint16_t> consideredQubits{};
   Node                    node{};
   TwoQubitMultiplicity    twoQubitGateMultiplicity{};
-  
+
   for (const auto& gate : layers.at(layer)) {
     if (!gate.singleQubit()) {
       const bool  reverse = gate.control >= gate.target;
@@ -432,9 +431,8 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
   node.locations = locations;
   node.qubits    = qubits;
   node.recalculateFixedCost(architecture);
-  node.updateHeuristicCost(
-      architecture, twoQubitGateMultiplicity,
-      results.config.admissibleHeuristic);
+  node.updateHeuristicCost(architecture, twoQubitGateMultiplicity,
+                           results.config.admissibleHeuristic);
 
   nodes.push(node);
 
@@ -457,8 +455,7 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
 
 void HeuristicMapper::expandNode(
     const std::set<std::uint16_t>& consideredQubits, Node& node,
-    std::size_t layer,
-    const TwoQubitMultiplicity&    twoQubitGateMultiplicity) {
+    std::size_t layer, const TwoQubitMultiplicity& twoQubitGateMultiplicity) {
   std::vector<std::vector<bool>> usedSwaps;
   usedSwaps.reserve(architecture.getNqubits());
   for (int p = 0; p < architecture.getNqubits(); ++p) {
@@ -533,11 +530,11 @@ void HeuristicMapper::expandNode(
 
 void HeuristicMapper::expandNodeAddOneSwap(
     const Edge& swap, Node& node, const std::size_t layer,
-    const TwoQubitMultiplicity&    twoQubitGateMultiplicity) {
-  const auto& config       = results.config;
+    const TwoQubitMultiplicity& twoQubitGateMultiplicity) {
+  const auto& config = results.config;
 
   Node newNode = Node(node.qubits, node.locations, node.swaps, node.costFixed);
-  
+
   if (architecture.getCouplingMap().find(swap) !=
           architecture.getCouplingMap().end() ||
       architecture.getCouplingMap().find(Edge{swap.second, swap.first}) !=
@@ -547,8 +544,7 @@ void HeuristicMapper::expandNodeAddOneSwap(
     newNode.applyTeleportation(swap, architecture);
   }
 
-  newNode.updateHeuristicCost(architecture,
-                              twoQubitGateMultiplicity,
+  newNode.updateHeuristicCost(architecture, twoQubitGateMultiplicity,
                               results.config.admissibleHeuristic);
 
   // calculate heuristics for the cost of the following layers
@@ -620,9 +616,7 @@ void HeuristicMapper::lookahead(const std::size_t      layer,
   }
 }
 
-
-void HeuristicMapper::Node::applySWAP(
-    const Edge& swap, Architecture& arch) {
+void HeuristicMapper::Node::applySWAP(const Edge& swap, Architecture& arch) {
   nswaps++;
   swaps.emplace_back();
   const auto q1 = qubits.at(swap.first);
@@ -732,8 +726,8 @@ void HeuristicMapper::Node::recalculateFixedCost(const Architecture& arch) {
 }
 
 void HeuristicMapper::Node::updateHeuristicCost(
-    const Architecture&         arch, 
-    const TwoQubitMultiplicity& twoQubitGateMultiplicity, 
+    const Architecture&         arch,
+    const TwoQubitMultiplicity& twoQubitGateMultiplicity,
     bool                        admissibleHeuristic) {
   costHeur = 0.;
   done     = true;
@@ -759,7 +753,7 @@ void HeuristicMapper::Node::updateHeuristicCost(
     if (!edgeDone) {
       done = false;
     }
-    
+
     double swapCostStraight =
         arch.distance(static_cast<std::uint16_t>(locations.at(q1)),
                       static_cast<std::uint16_t>(locations.at(q2)));

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -400,23 +400,27 @@ void HeuristicMapper::mapToMinDistance(const std::uint16_t source,
 
 HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
   std::unordered_set<std::uint16_t> consideredQubits{};
-  Node                    node{};
-  TwoQubitMultiplicity    twoQubitGateMultiplicity{};
+  Node                              node{};
+  TwoQubitMultiplicity              twoQubitGateMultiplicity{};
 
   for (const auto& gate : layers.at(layer)) {
     if (!gate.singleQubit()) {
       consideredQubits.emplace(gate.control);
       consideredQubits.emplace(gate.target);
-      if(gate.control >= gate.target) {
-        const auto edge = std::pair(gate.target, static_cast<std::uint16_t>(gate.control));
-        if (twoQubitGateMultiplicity.find(edge) == twoQubitGateMultiplicity.end()) {
+      if (gate.control >= gate.target) {
+        const auto edge =
+            std::pair(gate.target, static_cast<std::uint16_t>(gate.control));
+        if (twoQubitGateMultiplicity.find(edge) ==
+            twoQubitGateMultiplicity.end()) {
           twoQubitGateMultiplicity[edge] = {0, 1};
         } else {
           twoQubitGateMultiplicity[edge].second++;
         }
       } else {
-        const auto edge = std::pair(static_cast<std::uint16_t>(gate.control), gate.target);
-        if (twoQubitGateMultiplicity.find(edge) == twoQubitGateMultiplicity.end()) {
+        const auto edge =
+            std::pair(static_cast<std::uint16_t>(gate.control), gate.target);
+        if (twoQubitGateMultiplicity.find(edge) ==
+            twoQubitGateMultiplicity.end()) {
           twoQubitGateMultiplicity[edge] = {1, 0};
         } else {
           twoQubitGateMultiplicity[edge].first++;
@@ -735,18 +739,18 @@ void HeuristicMapper::Node::updateHeuristicCost(
   // current layer
   for (const auto& [edge, multiplicity] : twoQubitGateMultiplicity) {
     const auto& [q1, q2] = edge;
-    
+
     const auto& [straightMultiplicity, reverseMultiplicity] = multiplicity;
 
     // only if all qubit pairs are mapped next to each other the mapping
     // is complete
     if (arch.getCouplingMap().find(
             {static_cast<std::uint16_t>(locations.at(q1)),
-            static_cast<std::uint16_t>(locations.at(q2))}) ==
+             static_cast<std::uint16_t>(locations.at(q2))}) ==
             arch.getCouplingMap().end() &&
         arch.getCouplingMap().find(
             {static_cast<std::uint16_t>(locations.at(q2)),
-            static_cast<std::uint16_t>(locations.at(q1))}) ==
+             static_cast<std::uint16_t>(locations.at(q1))}) ==
             arch.getCouplingMap().end()) {
       done = false;
     }

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -30,8 +30,8 @@ protected:
 };
 
 TEST(Functionality, NodeCostCalculation) {
-  const double tolerance = 1e-6;
-  const CouplingMap    cm = {{0, 1}, {1, 2}, {3, 1}, {4, 3}};
+  const double         tolerance = 1e-6;
+  const CouplingMap    cm        = {{0, 1}, {1, 2}, {3, 1}, {4, 3}};
   Architecture         arch{5, cm};
   TwoQubitMultiplicity multiplicity = {{{0, 1}, {5, 2}}, {{2, 3}, {0, 1}}};
   std::array<std::int16_t, MAX_DEVICE_QUBITS> qubits    = {4, 3, 1, 2, 0};
@@ -48,7 +48,8 @@ TEST(Functionality, NodeCostCalculation) {
               COST_UNIDIRECTIONAL_SWAP * 2 + COST_DIRECTION_REVERSE, tolerance);
   node.updateHeuristicCost(arch, multiplicity, false);
   EXPECT_NEAR(node.costHeur,
-              COST_UNIDIRECTIONAL_SWAP * 14 + COST_DIRECTION_REVERSE * 3, tolerance);
+              COST_UNIDIRECTIONAL_SWAP * 14 + COST_DIRECTION_REVERSE * 3,
+              tolerance);
   node.applySWAP({3, 4}, arch);
   node.updateHeuristicCost(arch, multiplicity, true);
   EXPECT_NEAR(node.costFixed, 5. + COST_UNIDIRECTIONAL_SWAP, tolerance);
@@ -56,12 +57,16 @@ TEST(Functionality, NodeCostCalculation) {
               tolerance);
   node.lookaheadPenalty = 0.;
   EXPECT_NEAR(node.getTotalCost(),
-              5. + COST_UNIDIRECTIONAL_SWAP * 2 + COST_DIRECTION_REVERSE, tolerance);
-  EXPECT_NEAR(node.getTotalFixedCost(), 5. + COST_UNIDIRECTIONAL_SWAP, tolerance);
+              5. + COST_UNIDIRECTIONAL_SWAP * 2 + COST_DIRECTION_REVERSE,
+              tolerance);
+  EXPECT_NEAR(node.getTotalFixedCost(), 5. + COST_UNIDIRECTIONAL_SWAP,
+              tolerance);
   node.lookaheadPenalty = 2.;
   EXPECT_NEAR(node.getTotalCost(),
-              7. + COST_UNIDIRECTIONAL_SWAP * 2 + COST_DIRECTION_REVERSE, tolerance);
-  EXPECT_NEAR(node.getTotalFixedCost(), 7. + COST_UNIDIRECTIONAL_SWAP, tolerance);
+              7. + COST_UNIDIRECTIONAL_SWAP * 2 + COST_DIRECTION_REVERSE,
+              tolerance);
+  EXPECT_NEAR(node.getTotalFixedCost(), 7. + COST_UNIDIRECTIONAL_SWAP,
+              tolerance);
   node.recalculateFixedCost(arch);
   EXPECT_NEAR(node.costFixed, COST_TELEPORTATION + COST_UNIDIRECTIONAL_SWAP * 2,
               tolerance);
@@ -72,7 +77,8 @@ TEST(Functionality, NodeCostCalculation) {
                   COST_DIRECTION_REVERSE,
               tolerance);
   EXPECT_NEAR(node.getTotalFixedCost(),
-              2. + COST_TELEPORTATION + COST_UNIDIRECTIONAL_SWAP * 2, tolerance);
+              2. + COST_TELEPORTATION + COST_UNIDIRECTIONAL_SWAP * 2,
+              tolerance);
 }
 
 TEST(Functionality, EmptyDump) {

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -36,7 +36,8 @@ TEST(Functionality, NodeCostCalculation) {
   std::array<std::int16_t, MAX_DEVICE_QUBITS> qubits    = {4, 3, 1, 2, 0};
   std::array<std::int16_t, MAX_DEVICE_QUBITS> locations = {4, 2, 3, 1, 0};
   std::vector<std::vector<Exchange>>          swaps     = {
-      {Exchange(0, 1, qc::OpType::SWAP)}, {Exchange(1, 2, qc::OpType::SWAP)}};
+      {Exchange(0, 1, qc::OpType::Teleportation)}, 
+      {Exchange(1, 2, qc::OpType::SWAP)}};
   HeuristicMapper::Node node(qubits, locations, swaps, 5.);
   EXPECT_NEAR(node.costFixed, 5., 1e-6);
   node.updateHeuristicCost(arch, multiplicity, true);
@@ -59,13 +60,11 @@ TEST(Functionality, NodeCostCalculation) {
               7. + COST_UNIDIRECTIONAL_SWAP * 2 + COST_DIRECTION_REVERSE, 1e-6);
   EXPECT_NEAR(node.getTotalFixedCost(), 7. + COST_UNIDIRECTIONAL_SWAP, 1e-6);
   node.recalculateFixedCost(arch);
-  EXPECT_NEAR(node.costFixed, COST_UNIDIRECTIONAL_SWAP * 3, 1e-6);
+  EXPECT_NEAR(node.costFixed, COST_TELEPORTATION + COST_UNIDIRECTIONAL_SWAP * 2, 1e-6);
   EXPECT_NEAR(node.costHeur, COST_UNIDIRECTIONAL_SWAP + COST_DIRECTION_REVERSE,
               1e-6);
-  EXPECT_NEAR(node.getTotalCost(),
-              2. + COST_UNIDIRECTIONAL_SWAP * 4 + COST_DIRECTION_REVERSE, 1e-6);
-  EXPECT_NEAR(node.getTotalFixedCost(), 2. + COST_UNIDIRECTIONAL_SWAP * 3,
-              1e-6);
+  EXPECT_NEAR(node.getTotalCost(), 2. + COST_TELEPORTATION + COST_UNIDIRECTIONAL_SWAP * 3 + COST_DIRECTION_REVERSE, 1e-6);
+  EXPECT_NEAR(node.getTotalFixedCost(), 2. + COST_TELEPORTATION + COST_UNIDIRECTIONAL_SWAP * 2, 1e-6);
 }
 
 TEST(Functionality, EmptyDump) {

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -30,6 +30,7 @@ protected:
 };
 
 TEST(Functionality, NodeCostCalculation) {
+  const double tolerance = 1e-6;
   const CouplingMap    cm = {{0, 1}, {1, 2}, {3, 1}, {4, 3}};
   Architecture         arch{5, cm};
   TwoQubitMultiplicity multiplicity = {{{0, 1}, {5, 2}}, {{2, 3}, {0, 1}}};
@@ -41,37 +42,37 @@ TEST(Functionality, NodeCostCalculation) {
       {Exchange(1, 2, qc::OpType::SWAP)}};
 
   HeuristicMapper::Node node(qubits, locations, swaps, 5.);
-  EXPECT_NEAR(node.costFixed, 5., 1e-6);
+  EXPECT_NEAR(node.costFixed, 5., tolerance);
   node.updateHeuristicCost(arch, multiplicity, true);
   EXPECT_NEAR(node.costHeur,
-              COST_UNIDIRECTIONAL_SWAP * 2 + COST_DIRECTION_REVERSE, 1e-6);
+              COST_UNIDIRECTIONAL_SWAP * 2 + COST_DIRECTION_REVERSE, tolerance);
   node.updateHeuristicCost(arch, multiplicity, false);
   EXPECT_NEAR(node.costHeur,
-              COST_UNIDIRECTIONAL_SWAP * 14 + COST_DIRECTION_REVERSE * 3, 1e-6);
+              COST_UNIDIRECTIONAL_SWAP * 14 + COST_DIRECTION_REVERSE * 3, tolerance);
   node.applySWAP({3, 4}, arch);
   node.updateHeuristicCost(arch, multiplicity, true);
-  EXPECT_NEAR(node.costFixed, 5. + COST_UNIDIRECTIONAL_SWAP, 1e-6);
+  EXPECT_NEAR(node.costFixed, 5. + COST_UNIDIRECTIONAL_SWAP, tolerance);
   EXPECT_NEAR(node.costHeur, COST_UNIDIRECTIONAL_SWAP + COST_DIRECTION_REVERSE,
-              1e-6);
+              tolerance);
   node.lookaheadPenalty = 0.;
   EXPECT_NEAR(node.getTotalCost(),
-              5. + COST_UNIDIRECTIONAL_SWAP * 2 + COST_DIRECTION_REVERSE, 1e-6);
-  EXPECT_NEAR(node.getTotalFixedCost(), 5. + COST_UNIDIRECTIONAL_SWAP, 1e-6);
+              5. + COST_UNIDIRECTIONAL_SWAP * 2 + COST_DIRECTION_REVERSE, tolerance);
+  EXPECT_NEAR(node.getTotalFixedCost(), 5. + COST_UNIDIRECTIONAL_SWAP, tolerance);
   node.lookaheadPenalty = 2.;
   EXPECT_NEAR(node.getTotalCost(),
-              7. + COST_UNIDIRECTIONAL_SWAP * 2 + COST_DIRECTION_REVERSE, 1e-6);
-  EXPECT_NEAR(node.getTotalFixedCost(), 7. + COST_UNIDIRECTIONAL_SWAP, 1e-6);
+              7. + COST_UNIDIRECTIONAL_SWAP * 2 + COST_DIRECTION_REVERSE, tolerance);
+  EXPECT_NEAR(node.getTotalFixedCost(), 7. + COST_UNIDIRECTIONAL_SWAP, tolerance);
   node.recalculateFixedCost(arch);
   EXPECT_NEAR(node.costFixed, COST_TELEPORTATION + COST_UNIDIRECTIONAL_SWAP * 2,
-              1e-6);
+              tolerance);
   EXPECT_NEAR(node.costHeur, COST_UNIDIRECTIONAL_SWAP + COST_DIRECTION_REVERSE,
-              1e-6);
+              tolerance);
   EXPECT_NEAR(node.getTotalCost(),
               2. + COST_TELEPORTATION + COST_UNIDIRECTIONAL_SWAP * 3 +
                   COST_DIRECTION_REVERSE,
-              1e-6);
+              tolerance);
   EXPECT_NEAR(node.getTotalFixedCost(),
-              2. + COST_TELEPORTATION + COST_UNIDIRECTIONAL_SWAP * 2, 1e-6);
+              2. + COST_TELEPORTATION + COST_UNIDIRECTIONAL_SWAP * 2, tolerance);
 }
 
 TEST(Functionality, EmptyDump) {

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -30,33 +30,42 @@ protected:
 };
 
 TEST(Functionality, NodeCostCalculation) {
-  const CouplingMap cm = {{0,1},{1,2},{3,1},{4,3}};
-  Architecture arch{5, cm};
-  TwoQubitMultiplicity multiplicity = {{{0,1},{5,2}},{{2,3},{0,1}}};
+  const CouplingMap    cm = {{0, 1}, {1, 2}, {3, 1}, {4, 3}};
+  Architecture         arch{5, cm};
+  TwoQubitMultiplicity multiplicity = {{{0, 1}, {5, 2}}, {{2, 3}, {0, 1}}};
   std::array<std::int16_t, MAX_DEVICE_QUBITS> qubits    = {4, 3, 1, 2, 0};
   std::array<std::int16_t, MAX_DEVICE_QUBITS> locations = {4, 2, 3, 1, 0};
-  std::vector<std::vector<Exchange>>          swaps     = {{Exchange(0,1,qc::OpType::SWAP)}, {Exchange(1,2,qc::OpType::SWAP)}};
+  std::vector<std::vector<Exchange>>          swaps     = {
+      {Exchange(0, 1, qc::OpType::SWAP)}, {Exchange(1, 2, qc::OpType::SWAP)}};
   HeuristicMapper::Node node(qubits, locations, swaps, 5.);
   EXPECT_NEAR(node.costFixed, 5., 1e-6);
   node.updateHeuristicCost(arch, multiplicity, true);
-  EXPECT_NEAR(node.costHeur, COST_UNIDIRECTIONAL_SWAP*2+COST_DIRECTION_REVERSE, 1e-6);
+  EXPECT_NEAR(node.costHeur,
+              COST_UNIDIRECTIONAL_SWAP * 2 + COST_DIRECTION_REVERSE, 1e-6);
   node.updateHeuristicCost(arch, multiplicity, false);
-  EXPECT_NEAR(node.costHeur, COST_UNIDIRECTIONAL_SWAP*14+COST_DIRECTION_REVERSE*3, 1e-6);
-  node.applySWAP({3,4}, arch);
+  EXPECT_NEAR(node.costHeur,
+              COST_UNIDIRECTIONAL_SWAP * 14 + COST_DIRECTION_REVERSE * 3, 1e-6);
+  node.applySWAP({3, 4}, arch);
   node.updateHeuristicCost(arch, multiplicity, true);
   EXPECT_NEAR(node.costFixed, 5. + COST_UNIDIRECTIONAL_SWAP, 1e-6);
-  EXPECT_NEAR(node.costHeur, COST_UNIDIRECTIONAL_SWAP + COST_DIRECTION_REVERSE, 1e-6);
+  EXPECT_NEAR(node.costHeur, COST_UNIDIRECTIONAL_SWAP + COST_DIRECTION_REVERSE,
+              1e-6);
   node.lookaheadPenalty = 0.;
-  EXPECT_NEAR(node.getTotalCost(), 5. + COST_UNIDIRECTIONAL_SWAP*2 + COST_DIRECTION_REVERSE, 1e-6);
+  EXPECT_NEAR(node.getTotalCost(),
+              5. + COST_UNIDIRECTIONAL_SWAP * 2 + COST_DIRECTION_REVERSE, 1e-6);
   EXPECT_NEAR(node.getTotalFixedCost(), 5. + COST_UNIDIRECTIONAL_SWAP, 1e-6);
   node.lookaheadPenalty = 2.;
-  EXPECT_NEAR(node.getTotalCost(), 7. + COST_UNIDIRECTIONAL_SWAP*2 + COST_DIRECTION_REVERSE, 1e-6);
+  EXPECT_NEAR(node.getTotalCost(),
+              7. + COST_UNIDIRECTIONAL_SWAP * 2 + COST_DIRECTION_REVERSE, 1e-6);
   EXPECT_NEAR(node.getTotalFixedCost(), 7. + COST_UNIDIRECTIONAL_SWAP, 1e-6);
   node.recalculateFixedCost(arch);
-  EXPECT_NEAR(node.costFixed, COST_UNIDIRECTIONAL_SWAP*3, 1e-6);
-  EXPECT_NEAR(node.costHeur, COST_UNIDIRECTIONAL_SWAP + COST_DIRECTION_REVERSE, 1e-6);
-  EXPECT_NEAR(node.getTotalCost(), 2. + COST_UNIDIRECTIONAL_SWAP*4 + COST_DIRECTION_REVERSE, 1e-6);
-  EXPECT_NEAR(node.getTotalFixedCost(), 2. + COST_UNIDIRECTIONAL_SWAP*3, 1e-6);
+  EXPECT_NEAR(node.costFixed, COST_UNIDIRECTIONAL_SWAP * 3, 1e-6);
+  EXPECT_NEAR(node.costHeur, COST_UNIDIRECTIONAL_SWAP + COST_DIRECTION_REVERSE,
+              1e-6);
+  EXPECT_NEAR(node.getTotalCost(),
+              2. + COST_UNIDIRECTIONAL_SWAP * 4 + COST_DIRECTION_REVERSE, 1e-6);
+  EXPECT_NEAR(node.getTotalFixedCost(), 2. + COST_UNIDIRECTIONAL_SWAP * 3,
+              1e-6);
 }
 
 TEST(Functionality, EmptyDump) {

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -35,9 +35,11 @@ TEST(Functionality, NodeCostCalculation) {
   TwoQubitMultiplicity multiplicity = {{{0, 1}, {5, 2}}, {{2, 3}, {0, 1}}};
   std::array<std::int16_t, MAX_DEVICE_QUBITS> qubits    = {4, 3, 1, 2, 0};
   std::array<std::int16_t, MAX_DEVICE_QUBITS> locations = {4, 2, 3, 1, 0};
-  std::vector<std::vector<Exchange>>          swaps     = {
+  
+  std::vector<std::vector<Exchange>> swaps = {
       {Exchange(0, 1, qc::OpType::Teleportation)},
       {Exchange(1, 2, qc::OpType::SWAP)}};
+  
   HeuristicMapper::Node node(qubits, locations, swaps, 5.);
   EXPECT_NEAR(node.costFixed, 5., 1e-6);
   node.updateHeuristicCost(arch, multiplicity, true);


### PR DESCRIPTION
## Description

- Replacing iterations over all gates in the heuristic with iterations over a collection counting gate multiplicities (i.e. the number of gates acting on each logical qubit)
- Moving large methods in `HeuristicMapper::Node` from hpp to cpp
- Moving all cost computations inside `HeuristicMapper::Node` methods, and only interacting with nodes via method calls

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
