### PR TITLE
Heuristic Benchmarking

### DIFF
--- a/docs/source/library/MappingResults.rst
+++ b/docs/source/library/MappingResults.rst
@@ -24,7 +24,7 @@ If specified in the call to the :code:`compile` method, the `weighted MaxSAT for
 
     .. autoattribute:: MappingResults.wcnf
 
-If :code:`Method::Heuristic` is used, some benchmark information is provided for the whole circuit
+If heuristic mapping is used and :code:`debug` is set to :code:`true`, some benchmark information is provided for the whole circuit
 
     .. autoattribute:: MappingResults.heuristic_benchmark
 

--- a/docs/source/library/MappingResults.rst
+++ b/docs/source/library/MappingResults.rst
@@ -24,6 +24,14 @@ If specified in the call to the :code:`compile` method, the `weighted MaxSAT for
 
     .. autoattribute:: MappingResults.wcnf
 
+If :code:`Method::Heuristic` is used, some benchmark information is provided for the whole circuit
+
+    .. autoattribute:: MappingResults.heuristic_benchmark
+
+and for each layer separately.
+
+    .. autoattribute:: MappingResults.layer_heuristic_benchmark
+
 In addition, the class provides methods to export to other formats.
 
     .. automethod:: MappingResults.json

--- a/docs/source/library/MappingResults.rst
+++ b/docs/source/library/MappingResults.rst
@@ -1,9 +1,10 @@
 Results
 =======
 
-This class captures additional results from the :code:`compile` method.
-
     .. currentmodule:: mqt.qmap
+
+This class captures additional results from the :func:`compile` method.
+
     .. autoclass:: MappingResults
 
 In addition to the mapped circuit
@@ -20,11 +21,11 @@ and information about the input and output circuits.
     .. autoattribute:: MappingResults.input
     .. autoattribute:: MappingResults.output
 
-If specified in the call to the :code:`compile` method, the `weighted MaxSAT formula <http://www.maxhs.org/docs/wdimacs.html>`_ is also tracked.
+If specified in the call to the :func:`compile` method, the `weighted MaxSAT formula <http://www.maxhs.org/docs/wdimacs.html>`_ is also tracked.
 
     .. autoattribute:: MappingResults.wcnf
 
-If heuristic mapping is used and :code:`debug` is set to :code:`true`, some benchmark information is provided for the whole circuit
+If the heuristic mapper is used and :code:`debug` is set to :code:`True`, some benchmark information is provided for the whole circuit
 
     .. autoattribute:: MappingResults.heuristic_benchmark
 

--- a/include/MappingResults.hpp
+++ b/include/MappingResults.hpp
@@ -109,17 +109,6 @@ struct MappingResults {
       benchmark["time_per_node"] = heuristicBenchmark.timePerNode;
       benchmark["average_branching_factor"] = heuristicBenchmark.averageBranchingFactor;
       benchmark["effective_branching_factor"] = heuristicBenchmark.effectiveBranchingFactor;
-      /*benchmark["layers"] = nlohmann::json::array();
-      auto& layerBenchmark = benchmark["layers"];
-      for (const auto& layer : layerHeuristicBenchmark) {
-        auto& layerStats = layerBenchmark.emplace_back();
-        layerStats["expanded_nodes"] = layer.expandedNodes;
-        layerStats["generated_nodes"] = layer.generatedNodes;
-        layerStats["solution_depth"] = layer.solutionDepth;
-        layerStats["time_per_node"] = layer.timePerNode;
-        layerStats["average_branching_factor"] = layer.averageBranchingFactor;
-        layerStats["effective_branching_factor"] = layer.effectiveBranchingFactor;
-      }*/
     }
     stats["additional_gates"] =
         static_cast<std::make_signed_t<decltype(output.gates)>>(output.gates) -

--- a/include/MappingResults.hpp
+++ b/include/MappingResults.hpp
@@ -27,6 +27,15 @@ struct MappingResults {
     std::size_t directionReverse = 0;
     std::size_t teleportations   = 0;
   };
+  
+  struct HeuristicBenchmarkInfo {
+    std::size_t expandedNodes            = 0;
+    std::size_t generatedNodes           = 0;
+    std::size_t solutionDepth            = 0;
+    double      timePerNode              = 0.;
+    double      averageBranchingFactor   = 0.;
+    double      effectiveBranchingFactor = 0.;
+  };
 
   CircuitInfo input{};
 
@@ -40,16 +49,21 @@ struct MappingResults {
   std::string mappedCircuit{};
 
   std::string wcnf{};
+  
+  HeuristicBenchmarkInfo heuristicBenchmark{};
+  std::vector<HeuristicBenchmarkInfo> layerHeuristicBenchmark{};
 
   MappingResults()          = default;
   virtual ~MappingResults() = default;
 
   virtual void copyInput(const MappingResults& mappingResults) {
-    input        = mappingResults.input;
-    architecture = mappingResults.architecture;
-    config       = mappingResults.config;
-    output       = mappingResults.output;
-    wcnf         = mappingResults.wcnf;
+    input                   = mappingResults.input;
+    architecture            = mappingResults.architecture;
+    config                  = mappingResults.config;
+    output                  = mappingResults.output;
+    wcnf                    = mappingResults.wcnf;
+    heuristicBenchmark      = mappingResults.heuristicBenchmark;
+    layerHeuristicBenchmark = mappingResults.layerHeuristicBenchmark;
   }
 
   [[nodiscard]] std::string toString() const { return json().dump(2); }
@@ -89,6 +103,23 @@ struct MappingResults {
       }
     } else if (config.method == Method::Heuristic) {
       stats["teleportations"] = output.teleportations;
+      auto& benchmark = stats["benchmark"];
+      benchmark["expanded_nodes"] = heuristicBenchmark.expandedNodes;
+      benchmark["generated_nodes"] = heuristicBenchmark.generatedNodes;
+      benchmark["time_per_node"] = heuristicBenchmark.timePerNode;
+      benchmark["average_branching_factor"] = heuristicBenchmark.averageBranchingFactor;
+      benchmark["effective_branching_factor"] = heuristicBenchmark.effectiveBranchingFactor;
+      /*benchmark["layers"] = nlohmann::json::array();
+      auto& layerBenchmark = benchmark["layers"];
+      for (const auto& layer : layerHeuristicBenchmark) {
+        auto& layerStats = layerBenchmark.emplace_back();
+        layerStats["expanded_nodes"] = layer.expandedNodes;
+        layerStats["generated_nodes"] = layer.generatedNodes;
+        layerStats["solution_depth"] = layer.solutionDepth;
+        layerStats["time_per_node"] = layer.timePerNode;
+        layerStats["average_branching_factor"] = layer.averageBranchingFactor;
+        layerStats["effective_branching_factor"] = layer.effectiveBranchingFactor;
+      }*/
     }
     stats["additional_gates"] =
         static_cast<std::make_signed_t<decltype(output.gates)>>(output.gates) -

--- a/include/MappingResults.hpp
+++ b/include/MappingResults.hpp
@@ -27,7 +27,7 @@ struct MappingResults {
     std::size_t directionReverse = 0;
     std::size_t teleportations   = 0;
   };
-  
+
   struct HeuristicBenchmarkInfo {
     std::size_t expandedNodes            = 0;
     std::size_t generatedNodes           = 0;
@@ -49,8 +49,8 @@ struct MappingResults {
   std::string mappedCircuit{};
 
   std::string wcnf{};
-  
-  HeuristicBenchmarkInfo heuristicBenchmark{};
+
+  HeuristicBenchmarkInfo              heuristicBenchmark{};
   std::vector<HeuristicBenchmarkInfo> layerHeuristicBenchmark{};
 
   MappingResults()          = default;
@@ -102,13 +102,15 @@ struct MappingResults {
         stats["WCNF"] = wcnf;
       }
     } else if (config.method == Method::Heuristic) {
-      stats["teleportations"] = output.teleportations;
-      auto& benchmark = stats["benchmark"];
-      benchmark["expanded_nodes"] = heuristicBenchmark.expandedNodes;
+      stats["teleportations"]      = output.teleportations;
+      auto& benchmark              = stats["benchmark"];
+      benchmark["expanded_nodes"]  = heuristicBenchmark.expandedNodes;
       benchmark["generated_nodes"] = heuristicBenchmark.generatedNodes;
-      benchmark["time_per_node"] = heuristicBenchmark.timePerNode;
-      benchmark["average_branching_factor"] = heuristicBenchmark.averageBranchingFactor;
-      benchmark["effective_branching_factor"] = heuristicBenchmark.effectiveBranchingFactor;
+      benchmark["time_per_node"]   = heuristicBenchmark.timePerNode;
+      benchmark["average_branching_factor"] =
+          heuristicBenchmark.averageBranchingFactor;
+      benchmark["effective_branching_factor"] =
+          heuristicBenchmark.effectiveBranchingFactor;
     }
     stats["additional_gates"] =
         static_cast<std::make_signed_t<decltype(output.gates)>>(output.gates) -

--- a/include/configuration/Configuration.hpp
+++ b/include/configuration/Configuration.hpp
@@ -27,6 +27,7 @@ struct Configuration {
   bool addMeasurementsToMappedCircuit = true;
 
   bool verbose = false;
+  bool debug   = false;
 
   // map to particular subgraph of architecture (in exact mapper)
   std::set<std::uint16_t> subgraph{};

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -5,6 +5,7 @@
 
 #include "Mapper.hpp"
 #include "heuristic/UniquePriorityQueue.hpp"
+
 #include <cmath>
 
 #pragma once
@@ -79,9 +80,8 @@ public:
     Node() = default;
     Node(const std::array<std::int16_t, MAX_DEVICE_QUBITS>& q,
          const std::array<std::int16_t, MAX_DEVICE_QUBITS>& loc,
-         const std::vector<std::vector<Exchange>>&          sw            = {},
-         const double                                       initCostFixed = 0,
-         const std::size_t                                  searchDepth   = 0)
+         const std::vector<std::vector<Exchange>>&          sw = {},
+         const double initCostFixed = 0, const std::size_t searchDepth = 0)
         : costFixed(initCostFixed), depth(searchDepth) {
       std::copy(q.begin(), q.end(), qubits.begin());
       std::copy(loc.begin(), loc.end(), locations.begin());
@@ -269,23 +269,27 @@ protected:
     }
     return currentCost + newCost;
   }
-  
-  static double computeEffectiveBranchingRate(std::size_t nodesProcessed, const std::size_t solutionDepth) {
+
+  static double computeEffectiveBranchingRate(std::size_t       nodesProcessed,
+                                              const std::size_t solutionDepth) {
     // N = (b*)^d + (b*)^(d-1) + ... + (b*)^2 + b* + 1
     // no closed-form solution for b*, so we use approximation via binary search
     if (solutionDepth == 0) {
       return 0.;
     }
     --nodesProcessed; // N - 1 = (b*)^d + (b*)^(d-1) + ... + (b*)^2 + b*
-    double lower = std::pow(static_cast<double>(nodesProcessed), 1.0 / static_cast<double>(solutionDepth))/static_cast<double>(solutionDepth);
-    double upper = std::pow(static_cast<double>(nodesProcessed), 1.0 / static_cast<double>(solutionDepth));
-    while (upper - lower > 2*EFFECTIVE_BRANCH_RATE_TOLERANCE) {
+    double lower = std::pow(static_cast<double>(nodesProcessed),
+                            1.0 / static_cast<double>(solutionDepth)) /
+                   static_cast<double>(solutionDepth);
+    double upper = std::pow(static_cast<double>(nodesProcessed),
+                            1.0 / static_cast<double>(solutionDepth));
+    while (upper - lower > 2 * EFFECTIVE_BRANCH_RATE_TOLERANCE) {
       const double mid = (lower + upper) / 2.0;
-      double sum = 0.0;
-      for(std::size_t i = 1; i <= solutionDepth; ++i) {
+      double       sum = 0.0;
+      for (std::size_t i = 1; i <= solutionDepth; ++i) {
         sum += std::pow(mid, i);
       }
-      if(sum < static_cast<double>(nodesProcessed)) {
+      if (sum < static_cast<double>(nodesProcessed)) {
         lower = mid;
       } else {
         upper = mid;

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -23,11 +23,11 @@
 using TwoQubitMultiplicity =
     std::map<Edge, std::pair<std::uint16_t, std::uint16_t>>;
 
-constexpr double EFFECTIVE_BRANCH_RATE_TOLERANCE = 1e-10;
-
 class HeuristicMapper : public Mapper {
 public:
   using Mapper::Mapper; // import constructors from parent class
+
+  static constexpr double EFFECTIVE_BRANCH_RATE_TOLERANCE = 1e-10;
 
   /**
    * @brief map the circuit passed at initialization to the architecture

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -278,11 +278,9 @@ protected:
       return 0.;
     }
     --nodesProcessed; // N - 1 = (b*)^d + (b*)^(d-1) + ... + (b*)^2 + b*
-    double lower = std::pow(static_cast<double>(nodesProcessed),
-                            1.0 / static_cast<double>(solutionDepth)) /
-                   static_cast<double>(solutionDepth);
     double upper = std::pow(static_cast<double>(nodesProcessed),
                             1.0 / static_cast<double>(solutionDepth));
+    double lower = upper / static_cast<double>(solutionDepth);
     while (upper - lower > 2 * EFFECTIVE_BRANCH_RATE_TOLERANCE) {
       const double mid = (lower + upper) / 2.0;
       double       sum = 0.0;

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -270,12 +270,13 @@ protected:
     return currentCost + newCost;
   }
   
-  static double computeEffectiveBranchingRate(const std::size_t nodesProcessed, const std::size_t solutionDepth) {
-    // N = (b*)^d + (b*)^(d-1) + ... + (b*)^2 + b*
+  static double computeEffectiveBranchingRate(std::size_t nodesProcessed, const std::size_t solutionDepth) {
+    // N = (b*)^d + (b*)^(d-1) + ... + (b*)^2 + b* + 1
     // no closed-form solution for b*, so we use approximation via binary search
     if (solutionDepth == 0) {
       return 0.;
     }
+    --nodesProcessed; // N - 1 = (b*)^d + (b*)^(d-1) + ... + (b*)^2 + b*
     double lower = std::pow(static_cast<double>(nodesProcessed), 1.0 / static_cast<double>(solutionDepth))/static_cast<double>(solutionDepth);
     double upper = std::pow(static_cast<double>(nodesProcessed), 1.0 / static_cast<double>(solutionDepth));
     while (upper - lower > 2*EFFECTIVE_BRANCH_RATE_TOLERANCE) {

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -5,6 +5,7 @@
 
 #include "Mapper.hpp"
 #include "heuristic/UniquePriorityQueue.hpp"
+#include <cmath>
 
 #pragma once
 
@@ -20,6 +21,8 @@
  */
 using TwoQubitMultiplicity =
     std::map<Edge, std::pair<std::uint16_t, std::uint16_t>>;
+
+constexpr double EFFECTIVE_BRANCH_RATE_TOLERANCE = 1e-10;
 
 class HeuristicMapper : public Mapper {
 public:
@@ -70,13 +73,16 @@ public:
     /** number of swaps used to get from mapping after last layer to the current
      * mapping */
     std::size_t nswaps = 0;
+    /** depth in search tree (starting with 0 at the root) */
+    std::size_t depth = 0;
 
     Node() = default;
     Node(const std::array<std::int16_t, MAX_DEVICE_QUBITS>& q,
          const std::array<std::int16_t, MAX_DEVICE_QUBITS>& loc,
          const std::vector<std::vector<Exchange>>&          sw            = {},
-         const double                                       initCostFixed = 0)
-        : costFixed(initCostFixed) {
+         const double                                       initCostFixed = 0,
+         const std::size_t                                  searchDepth   = 0)
+        : costFixed(initCostFixed), depth(searchDepth) {
       std::copy(q.begin(), q.end(), qubits.begin());
       std::copy(loc.begin(), loc.end(), locations.begin());
       std::copy(sw.begin(), sw.end(), std::back_inserter(swaps));
@@ -262,6 +268,29 @@ protected:
       return std::max(currentCost, newCost);
     }
     return currentCost + newCost;
+  }
+  
+  static double computeEffectiveBranchingRate(const std::size_t nodesProcessed, const std::size_t solutionDepth) {
+    // N = (b*)^d + (b*)^(d-1) + ... + (b*)^2 + b*
+    // no closed-form solution for b*, so we use approximation via binary search
+    if (solutionDepth == 0) {
+      return 0.;
+    }
+    double lower = std::pow(static_cast<double>(nodesProcessed), 1.0 / static_cast<double>(solutionDepth))/static_cast<double>(solutionDepth);
+    double upper = std::pow(static_cast<double>(nodesProcessed), 1.0 / static_cast<double>(solutionDepth));
+    while (upper - lower > 2*EFFECTIVE_BRANCH_RATE_TOLERANCE) {
+      const double mid = (lower + upper) / 2.0;
+      double sum = 0.0;
+      for(std::size_t i = 1; i <= solutionDepth; ++i) {
+        sum += std::pow(mid, i);
+      }
+      if(sum < static_cast<double>(nodesProcessed)) {
+        lower = mid;
+      } else {
+        upper = mid;
+      }
+    }
+    return (lower + upper) / 2.0;
   }
 };
 

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -228,7 +228,8 @@ PYBIND11_MODULE(pyqmap, m) {
       .def_readwrite("timeout", &MappingResults::timeout)
       .def_readwrite("mapped_circuit", &MappingResults::mappedCircuit)
       .def_readwrite("heuristic_benchmark", &MappingResults::heuristicBenchmark)
-      .def_readwrite("layer_heuristic_benchmark", &MappingResults::layerHeuristicBenchmark)
+      .def_readwrite("layer_heuristic_benchmark",
+                     &MappingResults::layerHeuristicBenchmark)
       .def_readwrite("wcnf", &MappingResults::wcnf)
       .def("json", &MappingResults::json)
       .def("csv", &MappingResults::csv)
@@ -252,16 +253,24 @@ PYBIND11_MODULE(pyqmap, m) {
                      &MappingResults::CircuitInfo::teleportations);
 
   // Heuristic benchmark information
-  py::class_<MappingResults::HeuristicBenchmarkInfo>(m, "HeuristicBenchmarkInfo",
-                                          "Heuristic benchmark information")
+  py::class_<MappingResults::HeuristicBenchmarkInfo>(
+      m, "HeuristicBenchmarkInfo", "Heuristic benchmark information")
       .def(py::init<>())
-      .def_readwrite("expanded_nodes", &MappingResults::HeuristicBenchmarkInfo::expandedNodes)
-      .def_readwrite("generated_nodes", &MappingResults::HeuristicBenchmarkInfo::generatedNodes)
-      .def_readwrite("solution_depth", &MappingResults::HeuristicBenchmarkInfo::solutionDepth)
-      .def_readwrite("time_per_node", &MappingResults::HeuristicBenchmarkInfo::timePerNode)
-      .def_readwrite("average_branching_factor", &MappingResults::HeuristicBenchmarkInfo::averageBranchingFactor)
-      .def_readwrite("effective_branching_factor", &MappingResults::HeuristicBenchmarkInfo::effectiveBranchingFactor);
-  
+      .def_readwrite("expanded_nodes",
+                     &MappingResults::HeuristicBenchmarkInfo::expandedNodes)
+      .def_readwrite("generated_nodes",
+                     &MappingResults::HeuristicBenchmarkInfo::generatedNodes)
+      .def_readwrite("solution_depth",
+                     &MappingResults::HeuristicBenchmarkInfo::solutionDepth)
+      .def_readwrite("time_per_node",
+                     &MappingResults::HeuristicBenchmarkInfo::timePerNode)
+      .def_readwrite(
+          "average_branching_factor",
+          &MappingResults::HeuristicBenchmarkInfo::averageBranchingFactor)
+      .def_readwrite(
+          "effective_branching_factor",
+          &MappingResults::HeuristicBenchmarkInfo::effectiveBranchingFactor);
+
   auto arch = py::class_<Architecture>(
       m, "Architecture", "Class representing device/backend information");
   auto properties = py::class_<Architecture::Properties>(

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -182,6 +182,7 @@ PYBIND11_MODULE(pyqmap, m) {
       .def(py::init<>())
       .def_readwrite("method", &Configuration::method)
       .def_readwrite("verbose", &Configuration::verbose)
+      .def_readwrite("debug", &Configuration::debug)
       .def_readwrite("layering", &Configuration::layering)
       .def_readwrite("initial_layout", &Configuration::initialLayout)
       .def_readwrite("lookahead", &Configuration::lookahead)

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -227,6 +227,8 @@ PYBIND11_MODULE(pyqmap, m) {
       .def_readwrite("time", &MappingResults::time)
       .def_readwrite("timeout", &MappingResults::timeout)
       .def_readwrite("mapped_circuit", &MappingResults::mappedCircuit)
+      .def_readwrite("heuristic_benchmark", &MappingResults::heuristicBenchmark)
+      .def_readwrite("layer_heuristic_benchmark", &MappingResults::layerHeuristicBenchmark)
       .def_readwrite("wcnf", &MappingResults::wcnf)
       .def("json", &MappingResults::json)
       .def("csv", &MappingResults::csv)
@@ -249,6 +251,17 @@ PYBIND11_MODULE(pyqmap, m) {
       .def_readwrite("teleportations",
                      &MappingResults::CircuitInfo::teleportations);
 
+  // Heuristic benchmark information
+  py::class_<MappingResults::HeuristicBenchmarkInfo>(m, "HeuristicBenchmarkInfo",
+                                          "Heuristic benchmark information")
+      .def(py::init<>())
+      .def_readwrite("expanded_nodes", &MappingResults::HeuristicBenchmarkInfo::expandedNodes)
+      .def_readwrite("generated_nodes", &MappingResults::HeuristicBenchmarkInfo::generatedNodes)
+      .def_readwrite("solution_depth", &MappingResults::HeuristicBenchmarkInfo::solutionDepth)
+      .def_readwrite("time_per_node", &MappingResults::HeuristicBenchmarkInfo::timePerNode)
+      .def_readwrite("average_branching_factor", &MappingResults::HeuristicBenchmarkInfo::averageBranchingFactor)
+      .def_readwrite("effective_branching_factor", &MappingResults::HeuristicBenchmarkInfo::effectiveBranchingFactor);
+  
   auto arch = py::class_<Architecture>(
       m, "Architecture", "Class representing device/backend information");
   auto properties = py::class_<Architecture::Properties>(

--- a/mqt/qmap/compile.py
+++ b/mqt/qmap/compile.py
@@ -76,6 +76,7 @@ def compile(  # noqa: A001
     post_mapping_optimizations: bool = True,
     add_measurements_to_mapped_circuit: bool = True,
     verbose: bool = False,
+    debug: bool = False,
 ) -> tuple[QuantumCircuit, MappingResults]:
     """Interface to the MQT QMAP tool for mapping quantum circuits.
 
@@ -101,6 +102,7 @@ def compile(  # noqa: A001
         post_mapping_optimizations: Run post-mapping optimizations. Defaults to True.
         add_measurements_to_mapped_circuit: Whether to add measurements at the end of the mapped circuit. Defaults to True.
         verbose: Print more detailed information during the mapping process. Defaults to False.
+        debug: Gather additional information during the mapping process (e.g. number of generated nodes, branching factors, ...). Defaults to False.
 
     Returns:
         The mapped circuit and the mapping results.
@@ -134,6 +136,7 @@ def compile(  # noqa: A001
     config.post_mapping_optimizations = post_mapping_optimizations
     config.add_measurements_to_mapped_circuit = add_measurements_to_mapped_circuit
     config.verbose = verbose
+    config.debug = debug
 
     results = map(circ, architecture, config)
 

--- a/mqt/qmap/pyqmap.pyi
+++ b/mqt/qmap/pyqmap.pyi
@@ -137,6 +137,7 @@ class Configuration:
     use_subsets: bool
     use_teleportation: bool
     verbose: bool
+    debug: bool
     def __init__(self) -> None: ...
     def json(self) -> dict[str, Any]: ...
 

--- a/src/configuration/Configuration.cpp
+++ b/src/configuration/Configuration.cpp
@@ -16,6 +16,7 @@ nlohmann::json Configuration::json() const {
   config["post_mapping_optimizations"]         = postMappingOptimizations;
   config["add_measurements_to_mapped_circuit"] = addMeasurementsToMappedCircuit;
   config["verbose"]                            = verbose;
+  config["debug"]                              = debug;
 
   if (method == Method::Heuristic) {
     auto& heuristic             = config["settings"];

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -152,7 +152,8 @@ void HeuristicMapper::map(const Configuration& configuration) {
            static_cast<double>(benchmark.expandedNodes));
     }
     if (benchmark.effectiveBranchingFactor > benchmark.averageBranchingFactor) {
-      throw QMAPException("Something wrong in benchmark tracking: effectiveBranchingFactor > averageBranchingFactor");
+      throw QMAPException("Something wrong in benchmark tracking: "
+                          "effectiveBranchingFactor > averageBranchingFactor");
     }
   }
 
@@ -507,7 +508,10 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
         layerResults.expandedNodes + 1, result.depth);
     if (layerResults.effectiveBranchingFactor >
         layerResults.averageBranchingFactor) {
-      throw QMAPException("Something wrong in benchmark tracking on layer " + std::to_string(layer) + ": effectiveBranchingFactor > averageBranchingFactor");
+      throw QMAPException(
+          "Something wrong in benchmark tracking on layer " +
+          std::to_string(layer) +
+          ": effectiveBranchingFactor > averageBranchingFactor");
     }
   }
 

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -152,11 +152,7 @@ void HeuristicMapper::map(const Configuration& configuration) {
            static_cast<double>(benchmark.expandedNodes));
     }
     if (benchmark.effectiveBranchingFactor > benchmark.averageBranchingFactor) {
-      throw QMAPException("Effective branching factor (" +
-                          std::to_string(benchmark.effectiveBranchingFactor) +
-                          ") is larger than average branching factor (" +
-                          std::to_string(benchmark.averageBranchingFactor) +
-                          ").");
+      throw QMAPException("Something wrong in benchmark tracking: effectiveBranchingFactor > averageBranchingFactor");
     }
   }
 
@@ -511,12 +507,7 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
         layerResults.expandedNodes + 1, result.depth);
     if (layerResults.effectiveBranchingFactor >
         layerResults.averageBranchingFactor) {
-      throw QMAPException(
-          "Effective branching factor (" +
-          std::to_string(layerResults.effectiveBranchingFactor) +
-          ") is larger than average branching factor (" +
-          std::to_string(layerResults.averageBranchingFactor) + ") on layer " +
-          std::to_string(layer) + ".");
+      throw QMAPException("Something wrong in benchmark tracking on layer " + std::to_string(layer) + ": effectiveBranchingFactor > averageBranchingFactor");
     }
   }
 

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -8,7 +8,7 @@
 #include <chrono>
 
 void HeuristicMapper::map(const Configuration& configuration) {
-  results = MappingResults{};
+  results        = MappingResults{};
   results.config = configuration;
   auto& config   = results.config;
   if (config.layering == Layering::OddGates ||
@@ -138,15 +138,21 @@ void HeuristicMapper::map(const Configuration& configuration) {
       }
     }
   }
-  
+
   if (results.heuristicBenchmark.expandedNodes > 0) {
-    results.heuristicBenchmark.timePerNode /= static_cast<double>(results.heuristicBenchmark.expandedNodes);
-    results.heuristicBenchmark.averageBranchingFactor = static_cast<double>(results.heuristicBenchmark.generatedNodes-layers.size()) / static_cast<double>(results.heuristicBenchmark.expandedNodes);
+    results.heuristicBenchmark.timePerNode /=
+        static_cast<double>(results.heuristicBenchmark.expandedNodes);
+    results.heuristicBenchmark.averageBranchingFactor =
+        static_cast<double>(results.heuristicBenchmark.generatedNodes -
+                            layers.size()) /
+        static_cast<double>(results.heuristicBenchmark.expandedNodes);
     for (const auto& layer : results.layerHeuristicBenchmark) {
-      results.heuristicBenchmark.effectiveBranchingFactor += layer.effectiveBranchingFactor*(static_cast<double>(layer.expandedNodes)/static_cast<double>(results.heuristicBenchmark.expandedNodes));
+      results.heuristicBenchmark.effectiveBranchingFactor +=
+          layer.effectiveBranchingFactor *
+          (static_cast<double>(layer.expandedNodes) /
+           static_cast<double>(results.heuristicBenchmark.expandedNodes));
     }
   }
-  
 
   // infer output permutation from qubit locations
   qcMapped.outputPermutation.clear();
@@ -412,7 +418,7 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
   std::unordered_set<std::uint16_t> consideredQubits{};
   Node                              node{};
   TwoQubitMultiplicity              twoQubitGateMultiplicity{};
-  
+
   results.layerHeuristicBenchmark.emplace_back();
 
   for (const auto& gate : layers.at(layer)) {
@@ -450,29 +456,36 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
                            results.config.admissibleHeuristic);
 
   nodes.push(node);
-  
+
   const auto start = std::chrono::steady_clock::now();
-  
+
   while (!nodes.top().done) {
-    
     Node current = nodes.top();
     nodes.pop();
     expandNode(consideredQubits, current, layer, twoQubitGateMultiplicity);
-    
+
     ++results.heuristicBenchmark.expandedNodes;
     ++results.layerHeuristicBenchmark.back().expandedNodes;
   }
-    
+
   const auto                          end  = std::chrono::steady_clock::now();
   const std::chrono::duration<double> diff = end - start;
   results.heuristicBenchmark.timePerNode += diff.count();
-  results.layerHeuristicBenchmark.back().generatedNodes = results.layerHeuristicBenchmark.back().expandedNodes + nodes.size();
-  results.heuristicBenchmark.generatedNodes += results.layerHeuristicBenchmark.back().generatedNodes;
+  results.layerHeuristicBenchmark.back().generatedNodes =
+      results.layerHeuristicBenchmark.back().expandedNodes + nodes.size();
+  results.heuristicBenchmark.generatedNodes +=
+      results.layerHeuristicBenchmark.back().generatedNodes;
   if (results.layerHeuristicBenchmark.back().expandedNodes > 0) {
-    results.layerHeuristicBenchmark.back().timePerNode = diff.count() / static_cast<double>(results.layerHeuristicBenchmark.back().expandedNodes);
-    results.layerHeuristicBenchmark.back().averageBranchingFactor = static_cast<double>(results.layerHeuristicBenchmark.back().generatedNodes-1) / static_cast<double>(results.layerHeuristicBenchmark.back().expandedNodes);
+    results.layerHeuristicBenchmark.back().timePerNode =
+        diff.count() /
+        static_cast<double>(
+            results.layerHeuristicBenchmark.back().expandedNodes);
+    results.layerHeuristicBenchmark.back().averageBranchingFactor =
+        static_cast<double>(
+            results.layerHeuristicBenchmark.back().generatedNodes - 1) /
+        static_cast<double>(
+            results.layerHeuristicBenchmark.back().expandedNodes);
   }
-  
 
   Node result = nodes.top();
   nodes.pop();
@@ -481,9 +494,12 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
   while (!nodes.empty()) {
     nodes.pop();
   }
-  
+
   results.layerHeuristicBenchmark.back().solutionDepth = result.depth;
-  results.layerHeuristicBenchmark.back().effectiveBranchingFactor = computeEffectiveBranchingRate(results.layerHeuristicBenchmark.back().expandedNodes+1, result.depth);
+  results.layerHeuristicBenchmark.back().effectiveBranchingFactor =
+      computeEffectiveBranchingRate(
+          results.layerHeuristicBenchmark.back().expandedNodes + 1,
+          result.depth);
 
   return result;
 }
@@ -568,7 +584,8 @@ void HeuristicMapper::expandNodeAddOneSwap(
     const TwoQubitMultiplicity& twoQubitGateMultiplicity) {
   const auto& config = results.config;
 
-  Node newNode = Node(node.qubits, node.locations, node.swaps, node.costFixed, node.depth+1);
+  Node newNode = Node(node.qubits, node.locations, node.swaps, node.costFixed,
+                      node.depth + 1);
 
   if (architecture.getCouplingMap().find(swap) !=
           architecture.getCouplingMap().end() ||

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -141,11 +141,9 @@ void HeuristicMapper::map(const Configuration& configuration) {
 
   if (config.debug && results.heuristicBenchmark.expandedNodes > 0) {
     auto& benchmark = results.heuristicBenchmark;
-    benchmark.timePerNode /=
-        static_cast<double>(benchmark.expandedNodes);
+    benchmark.timePerNode /= static_cast<double>(benchmark.expandedNodes);
     benchmark.averageBranchingFactor =
-        static_cast<double>(benchmark.generatedNodes -
-                            layers.size()) /
+        static_cast<double>(benchmark.generatedNodes - layers.size()) /
         static_cast<double>(benchmark.expandedNodes);
     for (const auto& layer : results.layerHeuristicBenchmark) {
       benchmark.effectiveBranchingFactor +=
@@ -154,7 +152,11 @@ void HeuristicMapper::map(const Configuration& configuration) {
            static_cast<double>(benchmark.expandedNodes));
     }
     if (benchmark.effectiveBranchingFactor > benchmark.averageBranchingFactor) {
-      throw QMAPException("Effective branching factor (" + std::to_string(benchmark.effectiveBranchingFactor) + ") is larger than average branching factor (" + std::to_string(benchmark.averageBranchingFactor) + ").");
+      throw QMAPException("Effective branching factor (" +
+                          std::to_string(benchmark.effectiveBranchingFactor) +
+                          ") is larger than average branching factor (" +
+                          std::to_string(benchmark.averageBranchingFactor) +
+                          ").");
     }
   }
 
@@ -423,7 +425,7 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
   Node                              node{};
   TwoQubitMultiplicity              twoQubitGateMultiplicity{};
   const auto&                       debug = results.config.debug;
-  
+
   if (debug) {
     results.layerHeuristicBenchmark.emplace_back();
   }
@@ -463,23 +465,23 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
                            results.config.admissibleHeuristic);
 
   nodes.push(node);
-  
-  const auto start = std::chrono::steady_clock::now();
-  auto& layerResults = results.layerHeuristicBenchmark.back();
-  auto& totalExpandedNodes = results.heuristicBenchmark.expandedNodes;
-  auto& layerExpandedNodes = layerResults.expandedNodes;
-  
+
+  const auto start              = std::chrono::steady_clock::now();
+  auto&      layerResults       = results.layerHeuristicBenchmark.back();
+  auto&      totalExpandedNodes = results.heuristicBenchmark.expandedNodes;
+  auto&      layerExpandedNodes = layerResults.expandedNodes;
+
   while (!nodes.top().done) {
     Node current = nodes.top();
     nodes.pop();
     expandNode(consideredQubits, current, layer, twoQubitGateMultiplicity);
-    
+
     if (debug) {
       ++totalExpandedNodes;
       ++layerExpandedNodes;
     }
   }
-  
+
   if (debug) {
     const auto                          end  = std::chrono::steady_clock::now();
     const std::chrono::duration<double> diff = end - start;
@@ -487,8 +489,11 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
     layerResults.generatedNodes = layerResults.expandedNodes + nodes.size();
     results.heuristicBenchmark.generatedNodes += layerResults.generatedNodes;
     if (layerResults.expandedNodes > 0) {
-      layerResults.timePerNode = diff.count() / static_cast<double>(layerResults.expandedNodes);
-      layerResults.averageBranchingFactor = static_cast<double>(layerResults.generatedNodes - 1) / static_cast<double>(layerResults.expandedNodes);
+      layerResults.timePerNode =
+          diff.count() / static_cast<double>(layerResults.expandedNodes);
+      layerResults.averageBranchingFactor =
+          static_cast<double>(layerResults.generatedNodes - 1) /
+          static_cast<double>(layerResults.expandedNodes);
     }
   }
 
@@ -499,12 +504,19 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
   while (!nodes.empty()) {
     nodes.pop();
   }
-  
+
   if (debug) {
-    layerResults.solutionDepth = result.depth;
-    layerResults.effectiveBranchingFactor = computeEffectiveBranchingRate(layerResults.expandedNodes + 1, result.depth);
-    if (layerResults.effectiveBranchingFactor > layerResults.averageBranchingFactor) {
-      throw QMAPException("Effective branching factor (" + std::to_string(layerResults.effectiveBranchingFactor) + ") is larger than average branching factor (" + std::to_string(layerResults.averageBranchingFactor) + ") on layer " + std::to_string(layer) + ".");
+    layerResults.solutionDepth            = result.depth;
+    layerResults.effectiveBranchingFactor = computeEffectiveBranchingRate(
+        layerResults.expandedNodes + 1, result.depth);
+    if (layerResults.effectiveBranchingFactor >
+        layerResults.averageBranchingFactor) {
+      throw QMAPException(
+          "Effective branching factor (" +
+          std::to_string(layerResults.effectiveBranchingFactor) +
+          ") is larger than average branching factor (" +
+          std::to_string(layerResults.averageBranchingFactor) + ") on layer " +
+          std::to_string(layer) + ".");
     }
   }
 

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -105,7 +105,7 @@ TEST(Functionality, HeuristicBenchmark) {
     qc.measure(static_cast<qc::Qubit>(i), i);
   }
 
-  const auto mapper = std::make_unique<HeuristicMapper>(qc, architecture);
+  const auto    mapper = std::make_unique<HeuristicMapper>(qc, architecture);
   Configuration settings{};
   settings.admissibleHeuristic      = true;
   settings.layering                 = Layering::DisjointQubits;
@@ -143,18 +143,14 @@ TEST(Functionality, HeuristicBenchmark) {
   EXPECT_EQ(layerResults0.solutionDepth, 1);
   EXPECT_EQ(layerResults0.generatedNodes, 6);
   EXPECT_EQ(layerResults0.expandedNodes, 1);
-  EXPECT_NEAR(layerResults0.averageBranchingFactor, 5.,
-              tolerance);
-  EXPECT_NEAR(layerResults0.effectiveBranchingFactor, 1.,
-              tolerance);
+  EXPECT_NEAR(layerResults0.averageBranchingFactor, 5., tolerance);
+  EXPECT_NEAR(layerResults0.effectiveBranchingFactor, 1., tolerance);
   const auto& layerResults1 = result.layerHeuristicBenchmark[1];
   EXPECT_EQ(layerResults1.solutionDepth, 1);
   EXPECT_EQ(layerResults1.generatedNodes, 5);
   EXPECT_EQ(layerResults1.expandedNodes, 1);
-  EXPECT_NEAR(layerResults1.averageBranchingFactor, 4.,
-              tolerance);
-  EXPECT_NEAR(layerResults1.effectiveBranchingFactor, 1.,
-              tolerance);
+  EXPECT_NEAR(layerResults1.averageBranchingFactor, 4., tolerance);
+  EXPECT_NEAR(layerResults1.effectiveBranchingFactor, 1., tolerance);
   EXPECT_EQ(result.heuristicBenchmark.generatedNodes, 11);
   EXPECT_EQ(result.heuristicBenchmark.expandedNodes, 2);
   EXPECT_NEAR(result.heuristicBenchmark.averageBranchingFactor, 4.5, tolerance);
@@ -238,7 +234,7 @@ TEST_P(HeuristicTest5Q, Static) {
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_heuristic_qx4_static.qasm");
   ibmqYorktownMapper->printResult(std::cout);
-  
+
   ibmqLondonMapper->map(settings);
   ibmqLondonMapper->dumpResult(GetParam() + "_heuristic_london_static.qasm");
   ibmqLondonMapper->printResult(std::cout);
@@ -252,7 +248,7 @@ TEST_P(HeuristicTest5Q, Dynamic) {
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_heuristic_qx4_dynamic.qasm");
   ibmqYorktownMapper->printResult(std::cout);
-  
+
   ibmqLondonMapper->map(settings);
   ibmqLondonMapper->dumpResult(GetParam() + "_heuristic_london_dynamic.qasm");
   ibmqLondonMapper->printResult(std::cout);
@@ -297,7 +293,7 @@ TEST_P(HeuristicTest16Q, Dynamic) {
 TEST_P(HeuristicTest16Q, Disjoint) {
   Configuration settings{};
   settings.layering = Layering::DisjointQubits;
-  settings.debug         = true;
+  settings.debug    = true;
   ibmQX5Mapper->map(settings);
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_disjoint.qasm");
   ibmQX5Mapper->printResult(std::cout);
@@ -307,7 +303,7 @@ TEST_P(HeuristicTest16Q, Disjoint) {
 TEST_P(HeuristicTest16Q, Disjoint2qBlocks) {
   Configuration settings{};
   settings.layering = Layering::Disjoint2qBlocks;
-  settings.debug         = true;
+  settings.debug    = true;
   ibmQX5Mapper->map(settings);
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_disjoint_2q.qasm");
   ibmQX5Mapper->printResult(std::cout);

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -32,14 +32,15 @@ protected:
 };
 
 TEST(Functionality, NodeCostCalculation) {
-  const double         tolerance = 1e-6;
-  const CouplingMap    cm        = {{0, 1}, {1, 2}, {3, 1}, {4, 3}};
-  Architecture         arch{5, cm};
-  TwoQubitMultiplicity multiplicity = {{{0, 1}, {5, 2}}, {{2, 3}, {0, 1}}};
-  std::array<std::int16_t, MAX_DEVICE_QUBITS> qubits    = {4, 3, 1, 2, 0};
-  std::array<std::int16_t, MAX_DEVICE_QUBITS> locations = {4, 2, 3, 1, 0};
+  const double               tolerance = 1e-6;
+  const CouplingMap          cm        = {{0, 1}, {1, 2}, {3, 1}, {4, 3}};
+  Architecture               arch{5, cm};
+  const TwoQubitMultiplicity multiplicity                  = {{{0, 1}, {5, 2}},
+                                                              {{2, 3}, {0, 1}}};
+  const std::array<std::int16_t, MAX_DEVICE_QUBITS> qubits = {4, 3, 1, 2, 0};
+  const std::array<std::int16_t, MAX_DEVICE_QUBITS> locations = {4, 2, 3, 1, 0};
 
-  std::vector<std::vector<Exchange>> swaps = {
+  const std::vector<std::vector<Exchange>> swaps = {
       {Exchange(0, 1, qc::OpType::Teleportation)},
       {Exchange(1, 2, qc::OpType::SWAP)}};
 

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -105,7 +105,7 @@ TEST(Functionality, HeuristicBenchmark) {
     qc.measure(static_cast<qc::Qubit>(i), i);
   }
 
-  auto mapper = HeuristicMapper(qc, architecture);
+  const auto mapper = std::make_unique<HeuristicMapper>(qc, architecture);
   Configuration settings{};
   settings.admissibleHeuristic      = true;
   settings.layering                 = Layering::DisjointQubits;
@@ -113,8 +113,9 @@ TEST(Functionality, HeuristicBenchmark) {
   settings.preMappingOptimizations  = false;
   settings.postMappingOptimizations = false;
   settings.lookahead                = false;
-  mapper.map(settings);
-  auto& result = mapper.getResults();
+  settings.debug                    = true;
+  mapper->map(settings);
+  auto& result = mapper->getResults();
 
   /*
   generated nodes (unit of costs: COST_BIDIRECTIONAL_SWAP):
@@ -219,6 +220,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(HeuristicTest5Q, Identity) {
   Configuration settings{};
   settings.initialLayout = InitialLayout::Identity;
+  settings.debug         = true;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_heuristic_qx4_identity.qasm");
   ibmqYorktownMapper->printResult(std::cout);
@@ -238,6 +240,7 @@ TEST_P(HeuristicTest5Q, Identity) {
 TEST_P(HeuristicTest5Q, Static) {
   Configuration settings{};
   settings.initialLayout = InitialLayout::Static;
+  settings.debug         = true;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_heuristic_qx4_static.qasm");
   ibmqYorktownMapper->printResult(std::cout);
@@ -256,6 +259,7 @@ TEST_P(HeuristicTest5Q, Static) {
 TEST_P(HeuristicTest5Q, Dynamic) {
   Configuration settings{};
   settings.initialLayout = InitialLayout::Dynamic;
+  settings.debug         = true;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_heuristic_qx4_dynamic.qasm");
   ibmqYorktownMapper->printResult(std::cout);
@@ -299,6 +303,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(HeuristicTest16Q, Dynamic) {
   Configuration settings{};
   settings.initialLayout = InitialLayout::Dynamic;
+  settings.debug         = true;
   ibmQX5Mapper->map(settings);
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_dynamic.qasm");
   ibmQX5Mapper->printResult(std::cout);
@@ -311,6 +316,7 @@ TEST_P(HeuristicTest16Q, Dynamic) {
 TEST_P(HeuristicTest16Q, Disjoint) {
   Configuration settings{};
   settings.layering = Layering::DisjointQubits;
+  settings.debug         = true;
   ibmQX5Mapper->map(settings);
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_disjoint.qasm");
   ibmQX5Mapper->printResult(std::cout);
@@ -323,6 +329,7 @@ TEST_P(HeuristicTest16Q, Disjoint) {
 TEST_P(HeuristicTest16Q, Disjoint2qBlocks) {
   Configuration settings{};
   settings.layering = Layering::Disjoint2qBlocks;
+  settings.debug         = true;
   ibmQX5Mapper->map(settings);
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_disjoint_2q.qasm");
   ibmQX5Mapper->printResult(std::cout);
@@ -361,6 +368,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(HeuristicTest20Q, Dynamic) {
   Configuration settings{};
   settings.initialLayout = InitialLayout::Dynamic;
+  settings.debug         = true;
   tokyoMapper->map(settings);
   tokyoMapper->dumpResult(GetParam() + "_heuristic_tokyo_dynamic.qasm");
   tokyoMapper->printResult(std::cout);
@@ -403,6 +411,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(HeuristicTest20QTeleport, Teleportation) {
   Configuration settings{};
   settings.initialLayout       = InitialLayout::Dynamic;
+  settings.debug               = true;
   settings.teleportationQubits = std::min(
       (arch.getNqubits() - qc.getNqubits()) & ~1U, static_cast<std::size_t>(8));
   settings.teleportationSeed = std::get<0>(GetParam());

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -91,20 +91,21 @@ TEST(Functionality, HeuristicBenchmark) {
     0---1
   */
   Architecture      architecture{};
-  const CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 3}, {3, 2}, {3, 4}, {4, 3}, {4, 0}, {0, 4}};
+  const CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 3},
+                          {3, 2}, {3, 4}, {4, 3}, {4, 0}, {0, 4}};
   architecture.loadCouplingMap(5, cm);
-  
+
   qc::QuantumComputation qc{5, 5};
   qc.x(2, qc::Control{4});
   qc.x(1, qc::Control{3});
   qc.x(1, qc::Control{4});
-  
+
   qc.barrier({0, 1, 2, 3, 4});
   for (size_t i = 0; i < 5; ++i) {
     qc.measure(static_cast<qc::Qubit>(i), i);
   }
-  
-  const auto mapper = std::make_unique<HeuristicMapper>(qc, architecture);
+
+  const auto    mapper = std::make_unique<HeuristicMapper>(qc, architecture);
   Configuration settings{};
   settings.admissibleHeuristic      = true;
   settings.layering                 = Layering::DisjointQubits;
@@ -114,8 +115,8 @@ TEST(Functionality, HeuristicBenchmark) {
   settings.lookahead                = false;
   mapper->map(settings);
   auto& result = mapper->getResults();
-  
-  /* 
+
+  /*
   generated nodes (unit of costs: COST_BIDIRECTIONAL_SWAP):
   layer 1:
     0: {swaps: {}, cost: 0, heur: 1, total: 1}
@@ -135,22 +136,27 @@ TEST(Functionality, HeuristicBenchmark) {
     4: {swaps: {{4, 0}}, cost: 1, heur: 0, total: 1}
   --- priority queue: [1,4,2,3] -> done: 1
   */
-  
+
   EXPECT_EQ(result.layerHeuristicBenchmark.size(), 2);
   EXPECT_EQ(result.layerHeuristicBenchmark[0].solutionDepth, 1);
   EXPECT_EQ(result.layerHeuristicBenchmark[0].generatedNodes, 6);
   EXPECT_EQ(result.layerHeuristicBenchmark[0].expandedNodes, 1);
-  EXPECT_NEAR(result.layerHeuristicBenchmark[0].averageBranchingFactor, 5., tolerance);
-  EXPECT_NEAR(result.layerHeuristicBenchmark[0].effectiveBranchingFactor, 1., tolerance);
+  EXPECT_NEAR(result.layerHeuristicBenchmark[0].averageBranchingFactor, 5.,
+              tolerance);
+  EXPECT_NEAR(result.layerHeuristicBenchmark[0].effectiveBranchingFactor, 1.,
+              tolerance);
   EXPECT_EQ(result.layerHeuristicBenchmark[1].solutionDepth, 1);
   EXPECT_EQ(result.layerHeuristicBenchmark[1].generatedNodes, 5);
   EXPECT_EQ(result.layerHeuristicBenchmark[1].expandedNodes, 1);
-  EXPECT_NEAR(result.layerHeuristicBenchmark[1].averageBranchingFactor, 4., tolerance);
-  EXPECT_NEAR(result.layerHeuristicBenchmark[1].effectiveBranchingFactor, 1., tolerance);
+  EXPECT_NEAR(result.layerHeuristicBenchmark[1].averageBranchingFactor, 4.,
+              tolerance);
+  EXPECT_NEAR(result.layerHeuristicBenchmark[1].effectiveBranchingFactor, 1.,
+              tolerance);
   EXPECT_EQ(result.heuristicBenchmark.generatedNodes, 11);
   EXPECT_EQ(result.heuristicBenchmark.expandedNodes, 2);
   EXPECT_NEAR(result.heuristicBenchmark.averageBranchingFactor, 4.5, tolerance);
-  EXPECT_NEAR(result.heuristicBenchmark.effectiveBranchingFactor, 1., tolerance);
+  EXPECT_NEAR(result.heuristicBenchmark.effectiveBranchingFactor, 1.,
+              tolerance);
 }
 
 TEST(Functionality, EmptyDump) {
@@ -215,13 +221,15 @@ TEST_P(HeuristicTest5Q, Identity) {
   ibmqYorktownMapper->dumpResult(GetParam() + "_heuristic_qx4_identity.qasm");
   ibmqYorktownMapper->printResult(std::cout);
   auto& result = ibmqYorktownMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
+            result.heuristicBenchmark.averageBranchingFactor);
 
   ibmqLondonMapper->map(settings);
   ibmqLondonMapper->dumpResult(GetParam() + "_heuristic_london_identity.qasm");
   ibmqLondonMapper->printResult(std::cout);
   result = ibmqLondonMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
+            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -233,11 +241,13 @@ TEST_P(HeuristicTest5Q, Static) {
   ibmqYorktownMapper->printResult(std::cout);
   ibmqLondonMapper->map(settings);
   auto& result = ibmqYorktownMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
+            result.heuristicBenchmark.averageBranchingFactor);
   ibmqLondonMapper->dumpResult(GetParam() + "_heuristic_london_static.qasm");
   ibmqLondonMapper->printResult(std::cout);
   result = ibmqLondonMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
+            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -249,11 +259,13 @@ TEST_P(HeuristicTest5Q, Dynamic) {
   ibmqYorktownMapper->printResult(std::cout);
   ibmqLondonMapper->map(settings);
   auto& result = ibmqYorktownMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
+            result.heuristicBenchmark.averageBranchingFactor);
   ibmqLondonMapper->dumpResult(GetParam() + "_heuristic_london_dynamic.qasm");
   ibmqLondonMapper->printResult(std::cout);
   result = ibmqLondonMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
+            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -289,7 +301,8 @@ TEST_P(HeuristicTest16Q, Dynamic) {
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_dynamic.qasm");
   ibmQX5Mapper->printResult(std::cout);
   auto& result = ibmQX5Mapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
+            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -300,7 +313,8 @@ TEST_P(HeuristicTest16Q, Disjoint) {
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_disjoint.qasm");
   ibmQX5Mapper->printResult(std::cout);
   auto& result = ibmQX5Mapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
+            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -311,7 +325,8 @@ TEST_P(HeuristicTest16Q, Disjoint2qBlocks) {
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_disjoint_2q.qasm");
   ibmQX5Mapper->printResult(std::cout);
   auto& result = ibmQX5Mapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
+            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -348,7 +363,8 @@ TEST_P(HeuristicTest20Q, Dynamic) {
   tokyoMapper->dumpResult(GetParam() + "_heuristic_tokyo_dynamic.qasm");
   tokyoMapper->printResult(std::cout);
   auto& result = tokyoMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
+            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -393,6 +409,7 @@ TEST_P(HeuristicTest20QTeleport, Teleportation) {
                           "_heuristic_tokyo_teleport.qasm");
   tokyoMapper->printResult(std::cout);
   auto& result = tokyoMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
+            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -105,7 +105,7 @@ TEST(Functionality, HeuristicBenchmark) {
     qc.measure(static_cast<qc::Qubit>(i), i);
   }
 
-  const auto    mapper = std::make_unique<HeuristicMapper>(qc, architecture);
+  auto mapper = HeuristicMapper(qc, architecture);
   Configuration settings{};
   settings.admissibleHeuristic      = true;
   settings.layering                 = Layering::DisjointQubits;
@@ -113,8 +113,8 @@ TEST(Functionality, HeuristicBenchmark) {
   settings.preMappingOptimizations  = false;
   settings.postMappingOptimizations = false;
   settings.lookahead                = false;
-  mapper->map(settings);
-  auto& result = mapper->getResults();
+  mapper.map(settings);
+  auto& result = mapper.getResults();
 
   /*
   generated nodes (unit of costs: COST_BIDIRECTIONAL_SWAP):
@@ -138,19 +138,21 @@ TEST(Functionality, HeuristicBenchmark) {
   */
 
   EXPECT_EQ(result.layerHeuristicBenchmark.size(), 2);
-  EXPECT_EQ(result.layerHeuristicBenchmark[0].solutionDepth, 1);
-  EXPECT_EQ(result.layerHeuristicBenchmark[0].generatedNodes, 6);
-  EXPECT_EQ(result.layerHeuristicBenchmark[0].expandedNodes, 1);
-  EXPECT_NEAR(result.layerHeuristicBenchmark[0].averageBranchingFactor, 5.,
+  const auto& layerResults0 = result.layerHeuristicBenchmark[0];
+  EXPECT_EQ(layerResults0.solutionDepth, 1);
+  EXPECT_EQ(layerResults0.generatedNodes, 6);
+  EXPECT_EQ(layerResults0.expandedNodes, 1);
+  EXPECT_NEAR(layerResults0.averageBranchingFactor, 5.,
               tolerance);
-  EXPECT_NEAR(result.layerHeuristicBenchmark[0].effectiveBranchingFactor, 1.,
+  EXPECT_NEAR(layerResults0.effectiveBranchingFactor, 1.,
               tolerance);
-  EXPECT_EQ(result.layerHeuristicBenchmark[1].solutionDepth, 1);
-  EXPECT_EQ(result.layerHeuristicBenchmark[1].generatedNodes, 5);
-  EXPECT_EQ(result.layerHeuristicBenchmark[1].expandedNodes, 1);
-  EXPECT_NEAR(result.layerHeuristicBenchmark[1].averageBranchingFactor, 4.,
+  const auto& layerResults1 = result.layerHeuristicBenchmark[1];
+  EXPECT_EQ(layerResults1.solutionDepth, 1);
+  EXPECT_EQ(layerResults1.generatedNodes, 5);
+  EXPECT_EQ(layerResults1.expandedNodes, 1);
+  EXPECT_NEAR(layerResults1.averageBranchingFactor, 4.,
               tolerance);
-  EXPECT_NEAR(result.layerHeuristicBenchmark[1].effectiveBranchingFactor, 1.,
+  EXPECT_NEAR(layerResults1.effectiveBranchingFactor, 1.,
               tolerance);
   EXPECT_EQ(result.heuristicBenchmark.generatedNodes, 11);
   EXPECT_EQ(result.heuristicBenchmark.expandedNodes, 2);

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -18,6 +18,7 @@ protected:
   Architecture                     ibmqLondon{};
   std::unique_ptr<HeuristicMapper> ibmqYorktownMapper;
   std::unique_ptr<HeuristicMapper> ibmqLondonMapper;
+  Configuration                    settings{};
 
   void SetUp() override {
     qc.import(testExampleDir + GetParam() + ".qasm");
@@ -26,6 +27,7 @@ protected:
     ibmqLondon.loadProperties(testCalibrationDir + "ibmq_london.csv");
     ibmqYorktownMapper = std::make_unique<HeuristicMapper>(qc, ibmqYorktown);
     ibmqLondonMapper   = std::make_unique<HeuristicMapper>(qc, ibmqLondon);
+    settings.debug     = true;
   }
 };
 
@@ -218,9 +220,7 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 TEST_P(HeuristicTest5Q, Identity) {
-  Configuration settings{};
   settings.initialLayout = InitialLayout::Identity;
-  settings.debug         = true;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_heuristic_qx4_identity.qasm");
   ibmqYorktownMapper->printResult(std::cout);
@@ -232,9 +232,7 @@ TEST_P(HeuristicTest5Q, Identity) {
 }
 
 TEST_P(HeuristicTest5Q, Static) {
-  Configuration settings{};
   settings.initialLayout = InitialLayout::Static;
-  settings.debug         = true;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_heuristic_qx4_static.qasm");
   ibmqYorktownMapper->printResult(std::cout);
@@ -246,9 +244,7 @@ TEST_P(HeuristicTest5Q, Static) {
 }
 
 TEST_P(HeuristicTest5Q, Dynamic) {
-  Configuration settings{};
   settings.initialLayout = InitialLayout::Dynamic;
-  settings.debug         = true;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_heuristic_qx4_dynamic.qasm");
   ibmqYorktownMapper->printResult(std::cout);
@@ -267,11 +263,13 @@ protected:
   qc::QuantumComputation           qc{};
   Architecture                     ibmQX5{};
   std::unique_ptr<HeuristicMapper> ibmQX5Mapper;
+  Configuration                    settings{};
 
   void SetUp() override {
     qc.import(testExampleDir + GetParam() + ".qasm");
     ibmQX5.loadCouplingMap(AvailableArchitecture::IbmQx5);
-    ibmQX5Mapper = std::make_unique<HeuristicMapper>(qc, ibmQX5);
+    ibmQX5Mapper   = std::make_unique<HeuristicMapper>(qc, ibmQX5);
+    settings.debug = true;
   }
 };
 
@@ -285,9 +283,7 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 TEST_P(HeuristicTest16Q, Dynamic) {
-  Configuration settings{};
   settings.initialLayout = InitialLayout::Dynamic;
-  settings.debug         = true;
   ibmQX5Mapper->map(settings);
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_dynamic.qasm");
   ibmQX5Mapper->printResult(std::cout);
@@ -295,9 +291,7 @@ TEST_P(HeuristicTest16Q, Dynamic) {
 }
 
 TEST_P(HeuristicTest16Q, Disjoint) {
-  Configuration settings{};
   settings.layering = Layering::DisjointQubits;
-  settings.debug    = true;
   ibmQX5Mapper->map(settings);
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_disjoint.qasm");
   ibmQX5Mapper->printResult(std::cout);
@@ -305,9 +299,7 @@ TEST_P(HeuristicTest16Q, Disjoint) {
 }
 
 TEST_P(HeuristicTest16Q, Disjoint2qBlocks) {
-  Configuration settings{};
   settings.layering = Layering::Disjoint2qBlocks;
-  settings.debug    = true;
   ibmQX5Mapper->map(settings);
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_disjoint_2q.qasm");
   ibmQX5Mapper->printResult(std::cout);

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -224,16 +224,10 @@ TEST_P(HeuristicTest5Q, Identity) {
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_heuristic_qx4_identity.qasm");
   ibmqYorktownMapper->printResult(std::cout);
-  auto& result = ibmqYorktownMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
-            result.heuristicBenchmark.averageBranchingFactor);
 
   ibmqLondonMapper->map(settings);
   ibmqLondonMapper->dumpResult(GetParam() + "_heuristic_london_identity.qasm");
   ibmqLondonMapper->printResult(std::cout);
-  result = ibmqLondonMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
-            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -244,15 +238,10 @@ TEST_P(HeuristicTest5Q, Static) {
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_heuristic_qx4_static.qasm");
   ibmqYorktownMapper->printResult(std::cout);
+  
   ibmqLondonMapper->map(settings);
-  auto& result = ibmqYorktownMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
-            result.heuristicBenchmark.averageBranchingFactor);
   ibmqLondonMapper->dumpResult(GetParam() + "_heuristic_london_static.qasm");
   ibmqLondonMapper->printResult(std::cout);
-  result = ibmqLondonMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
-            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -263,15 +252,10 @@ TEST_P(HeuristicTest5Q, Dynamic) {
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_heuristic_qx4_dynamic.qasm");
   ibmqYorktownMapper->printResult(std::cout);
+  
   ibmqLondonMapper->map(settings);
-  auto& result = ibmqYorktownMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
-            result.heuristicBenchmark.averageBranchingFactor);
   ibmqLondonMapper->dumpResult(GetParam() + "_heuristic_london_dynamic.qasm");
   ibmqLondonMapper->printResult(std::cout);
-  result = ibmqLondonMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
-            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -307,9 +291,6 @@ TEST_P(HeuristicTest16Q, Dynamic) {
   ibmQX5Mapper->map(settings);
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_dynamic.qasm");
   ibmQX5Mapper->printResult(std::cout);
-  auto& result = ibmQX5Mapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
-            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -320,9 +301,6 @@ TEST_P(HeuristicTest16Q, Disjoint) {
   ibmQX5Mapper->map(settings);
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_disjoint.qasm");
   ibmQX5Mapper->printResult(std::cout);
-  auto& result = ibmQX5Mapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
-            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -333,9 +311,6 @@ TEST_P(HeuristicTest16Q, Disjoint2qBlocks) {
   ibmQX5Mapper->map(settings);
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_disjoint_2q.qasm");
   ibmQX5Mapper->printResult(std::cout);
-  auto& result = ibmQX5Mapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
-            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -372,9 +347,6 @@ TEST_P(HeuristicTest20Q, Dynamic) {
   tokyoMapper->map(settings);
   tokyoMapper->dumpResult(GetParam() + "_heuristic_tokyo_dynamic.qasm");
   tokyoMapper->printResult(std::cout);
-  auto& result = tokyoMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
-            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -419,8 +391,5 @@ TEST_P(HeuristicTest20QTeleport, Teleportation) {
   tokyoMapper->dumpResult(std::get<1>(GetParam()) +
                           "_heuristic_tokyo_teleport.qasm");
   tokyoMapper->printResult(std::cout);
-  auto& result = tokyoMapper->getResults();
-  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor,
-            result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -82,7 +82,6 @@ TEST(Functionality, NodeCostCalculation) {
 }
 
 TEST(Functionality, HeuristicBenchmark) {
-  const double tolerance = 1e-10;
   /*
       3
      / \
@@ -143,19 +142,24 @@ TEST(Functionality, HeuristicBenchmark) {
   EXPECT_EQ(layerResults0.solutionDepth, 1);
   EXPECT_EQ(layerResults0.generatedNodes, 6);
   EXPECT_EQ(layerResults0.expandedNodes, 1);
-  EXPECT_NEAR(layerResults0.averageBranchingFactor, 5., tolerance);
-  EXPECT_NEAR(layerResults0.effectiveBranchingFactor, 1., tolerance);
+  EXPECT_NEAR(layerResults0.averageBranchingFactor, 5.,
+              HeuristicMapper::EFFECTIVE_BRANCH_RATE_TOLERANCE);
+  EXPECT_NEAR(layerResults0.effectiveBranchingFactor, 1.,
+              HeuristicMapper::EFFECTIVE_BRANCH_RATE_TOLERANCE);
   const auto& layerResults1 = result.layerHeuristicBenchmark[1];
   EXPECT_EQ(layerResults1.solutionDepth, 1);
   EXPECT_EQ(layerResults1.generatedNodes, 5);
   EXPECT_EQ(layerResults1.expandedNodes, 1);
-  EXPECT_NEAR(layerResults1.averageBranchingFactor, 4., tolerance);
-  EXPECT_NEAR(layerResults1.effectiveBranchingFactor, 1., tolerance);
+  EXPECT_NEAR(layerResults1.averageBranchingFactor, 4.,
+              HeuristicMapper::EFFECTIVE_BRANCH_RATE_TOLERANCE);
+  EXPECT_NEAR(layerResults1.effectiveBranchingFactor, 1.,
+              HeuristicMapper::EFFECTIVE_BRANCH_RATE_TOLERANCE);
   EXPECT_EQ(result.heuristicBenchmark.generatedNodes, 11);
   EXPECT_EQ(result.heuristicBenchmark.expandedNodes, 2);
-  EXPECT_NEAR(result.heuristicBenchmark.averageBranchingFactor, 4.5, tolerance);
+  EXPECT_NEAR(result.heuristicBenchmark.averageBranchingFactor, 4.5,
+              HeuristicMapper::EFFECTIVE_BRANCH_RATE_TOLERANCE);
   EXPECT_NEAR(result.heuristicBenchmark.effectiveBranchingFactor, 1.,
-              tolerance);
+              HeuristicMapper::EFFECTIVE_BRANCH_RATE_TOLERANCE);
 }
 
 TEST(Functionality, EmptyDump) {

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -214,10 +214,14 @@ TEST_P(HeuristicTest5Q, Identity) {
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_heuristic_qx4_identity.qasm");
   ibmqYorktownMapper->printResult(std::cout);
+  auto& result = ibmqYorktownMapper->getResults();
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
 
   ibmqLondonMapper->map(settings);
   ibmqLondonMapper->dumpResult(GetParam() + "_heuristic_london_identity.qasm");
   ibmqLondonMapper->printResult(std::cout);
+  result = ibmqLondonMapper->getResults();
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -228,8 +232,12 @@ TEST_P(HeuristicTest5Q, Static) {
   ibmqYorktownMapper->dumpResult(GetParam() + "_heuristic_qx4_static.qasm");
   ibmqYorktownMapper->printResult(std::cout);
   ibmqLondonMapper->map(settings);
+  auto& result = ibmqYorktownMapper->getResults();
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
   ibmqLondonMapper->dumpResult(GetParam() + "_heuristic_london_static.qasm");
   ibmqLondonMapper->printResult(std::cout);
+  result = ibmqLondonMapper->getResults();
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -240,8 +248,12 @@ TEST_P(HeuristicTest5Q, Dynamic) {
   ibmqYorktownMapper->dumpResult(GetParam() + "_heuristic_qx4_dynamic.qasm");
   ibmqYorktownMapper->printResult(std::cout);
   ibmqLondonMapper->map(settings);
+  auto& result = ibmqYorktownMapper->getResults();
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
   ibmqLondonMapper->dumpResult(GetParam() + "_heuristic_london_dynamic.qasm");
   ibmqLondonMapper->printResult(std::cout);
+  result = ibmqLondonMapper->getResults();
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -276,6 +288,8 @@ TEST_P(HeuristicTest16Q, Dynamic) {
   ibmQX5Mapper->map(settings);
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_dynamic.qasm");
   ibmQX5Mapper->printResult(std::cout);
+  auto& result = ibmQX5Mapper->getResults();
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -285,6 +299,8 @@ TEST_P(HeuristicTest16Q, Disjoint) {
   ibmQX5Mapper->map(settings);
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_disjoint.qasm");
   ibmQX5Mapper->printResult(std::cout);
+  auto& result = ibmQX5Mapper->getResults();
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -294,6 +310,8 @@ TEST_P(HeuristicTest16Q, Disjoint2qBlocks) {
   ibmQX5Mapper->map(settings);
   ibmQX5Mapper->dumpResult(GetParam() + "_heuristic_qx5_disjoint_2q.qasm");
   ibmQX5Mapper->printResult(std::cout);
+  auto& result = ibmQX5Mapper->getResults();
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -329,6 +347,8 @@ TEST_P(HeuristicTest20Q, Dynamic) {
   tokyoMapper->map(settings);
   tokyoMapper->dumpResult(GetParam() + "_heuristic_tokyo_dynamic.qasm");
   tokyoMapper->printResult(std::cout);
+  auto& result = tokyoMapper->getResults();
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }
 
@@ -372,5 +392,7 @@ TEST_P(HeuristicTest20QTeleport, Teleportation) {
   tokyoMapper->dumpResult(std::get<1>(GetParam()) +
                           "_heuristic_tokyo_teleport.qasm");
   tokyoMapper->printResult(std::cout);
+  auto& result = tokyoMapper->getResults();
+  EXPECT_LE(result.heuristicBenchmark.effectiveBranchingFactor, result.heuristicBenchmark.averageBranchingFactor);
   SUCCEED() << "Mapping successful";
 }


### PR DESCRIPTION
## Description

Implements some benchmarks into the heuristic mapper (both for the whole mapping process, and for each layer):
- number of generated nodes
- number of expanded nodes
- depth of the retrieved solution in the search tree (only for each layer, not globally for the whole mapping process)
- average branching factor (i.e. how many children does a node generate on average)
- effective branching factor (i.e. how many of those children on average were expanded before the solution was found; or in other words the branching factor, which a balanced, uniform tree would need to have, to contain the number of processed nodes (expanded + 1) with a depth equal to the solution depth)
- the average time spent on each expanded node

All of this will help keeping track of performance changes, when implementing new heuristics or updating the existing heuristic.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
