### PR TITLE
Test heuristic for admissibility

### DIFF
--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -133,19 +133,20 @@ TEST(Functionality, HeuristicAdmissibility) {
   architecture.loadCouplingMap(6, cm);
   const std::vector<Edge> perms{{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5}};
 
-  TwoQubitMultiplicity multiplicity = {{{0, 4}, {1, 0}}, {{1, 3}, {1, 0}}, {{2, 5}, {1, 0}}};
-  
+  TwoQubitMultiplicity multiplicity = {
+      {{0, 4}, {1, 0}}, {{1, 3}, {1, 0}}, {{2, 5}, {1, 0}}};
+
   // perform depth-limited depth first search
-  const std::size_t depthLimit = 11;
+  const std::size_t                  depthLimit = 11;
   std::vector<HeuristicMapper::Node> stack{};
-  std::vector<std::size_t> currentPerm{};
-  
+  std::vector<std::size_t>           currentPerm{};
+
   auto initNode = HeuristicMapper::Node({0, 1, 2, 3, 4, 5}, {0, 1, 2, 3, 4, 5});
   initNode.recalculateFixedCost(architecture);
   initNode.updateHeuristicCost(architecture, multiplicity, true);
   stack.push_back(initNode);
   currentPerm.push_back(perms.size());
-  
+
   while (!stack.empty()) {
     auto& node = stack.back();
     if (node.done) {
@@ -160,8 +161,9 @@ TEST(Functionality, HeuristicAdmissibility) {
       continue;
     }
     --currentPerm.back();
-    auto perm = perms[currentPerm.back()];
-    auto newNode = HeuristicMapper::Node(node.qubits, node.locations, node.swaps, node.costFixed);
+    auto perm    = perms[currentPerm.back()];
+    auto newNode = HeuristicMapper::Node(node.qubits, node.locations,
+                                         node.swaps, node.costFixed);
     newNode.applySWAP(perm, architecture);
     newNode.updateHeuristicCost(architecture, multiplicity, true);
     stack.push_back(newNode);

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -161,9 +161,9 @@ TEST(Functionality, HeuristicAdmissibility) {
       continue;
     }
     --currentPerm.back();
-    const auto perm = perms[currentPerm.back()];
-    auto newNode = HeuristicMapper::Node(node.qubits, node.locations,
-                                         node.swaps, node.costFixed);
+    const auto perm    = perms[currentPerm.back()];
+    auto       newNode = HeuristicMapper::Node(node.qubits, node.locations,
+                                               node.swaps, node.costFixed);
     newNode.applySWAP(perm, architecture);
     newNode.updateHeuristicCost(architecture, multiplicity, true);
     stack.push_back(newNode);

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -148,10 +148,10 @@ TEST(Functionality, HeuristicAdmissibility) {
   currentPerm.push_back(perms.size());
 
   while (!stack.empty()) {
-    auto& node = stack.back();
+    const auto& node = stack.back();
     if (node.done) {
       // check if all nodes in stack have lower or equal cost
-      for (auto& prevNode : stack) {
+      for (const auto& prevNode : stack) {
         EXPECT_LE(prevNode.getTotalCost(), node.getTotalCost());
       }
     }
@@ -161,7 +161,7 @@ TEST(Functionality, HeuristicAdmissibility) {
       continue;
     }
     --currentPerm.back();
-    auto perm    = perms[currentPerm.back()];
+    const auto perm = perms[currentPerm.back()];
     auto newNode = HeuristicMapper::Node(node.qubits, node.locations,
                                          node.swaps, node.costFixed);
     newNode.applySWAP(perm, architecture);


### PR DESCRIPTION
## Description

Implements a new test performing depth-limited depth first search on a small mapping problem using `HeuristicMapper::Node` and checking heuristic costs on each solution search path for admissibility.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
