### PR TITLE
🚸 Allow for setting minimal timesteps for binary search.

### DIFF
--- a/include/cliffordsynthesis/Configuration.hpp
+++ b/include/cliffordsynthesis/Configuration.hpp
@@ -16,6 +16,7 @@ struct Configuration {
 
   /// General configuration for the synthesis algorithm
   std::size_t    initialTimestepLimit    = 0U;
+  std::size_t    minimalTimeSteps        = 0U;
   bool           useMaxSAT               = false;
   TargetMetric   target                  = TargetMetric::Gates;
   bool           useSymmetryBreaking     = true;
@@ -37,6 +38,7 @@ struct Configuration {
   [[nodiscard]] nlohmann::json json() const {
     nlohmann::json j;
     j["initial_timestep_limit"] = initialTimestepLimit;
+    j["minimal_timesteps"]      = minimalTimeSteps;
     j["use_max_sat"]            = useMaxSAT;
     j["target_metric"]          = toString(target);
     j["use_symmetry_breaking"]  = useSymmetryBreaking;

--- a/include/cliffordsynthesis/Configuration.hpp
+++ b/include/cliffordsynthesis/Configuration.hpp
@@ -16,7 +16,7 @@ struct Configuration {
 
   /// General configuration for the synthesis algorithm
   std::size_t    initialTimestepLimit    = 0U;
-  std::size_t    minimalTimeSteps        = 0U;
+  std::size_t    minimalTimesteps        = 0U;
   bool           useMaxSAT               = false;
   TargetMetric   target                  = TargetMetric::Gates;
   bool           useSymmetryBreaking     = true;
@@ -38,7 +38,7 @@ struct Configuration {
   [[nodiscard]] nlohmann::json json() const {
     nlohmann::json j;
     j["initial_timestep_limit"] = initialTimestepLimit;
-    j["minimal_timesteps"]      = minimalTimeSteps;
+    j["minimal_timesteps"]      = minimalTimesteps;
     j["use_max_sat"]            = useMaxSAT;
     j["target_metric"]          = toString(target);
     j["use_symmetry_breaking"]  = useSymmetryBreaking;

--- a/include/cliffordsynthesis/encoding/SATEncoder.hpp
+++ b/include/cliffordsynthesis/encoding/SATEncoder.hpp
@@ -35,6 +35,9 @@ public:
     // the number of timesteps to encode
     std::size_t timestepLimit{};
 
+    // minimal time steps of circuit
+    std::size_t minimalTimesteps{};
+
     // the metric to optimize
     TargetMetric targetMetric = TargetMetric::Gates;
 

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -434,6 +434,10 @@ PYBIND11_MODULE(pyqmap, m) {
                      "Initial timestep limit for the Clifford synthesis. "
                      "Defaults to `0`, which implies that the initial timestep "
                      "limit is determined automatically.")
+      .def_readwrite("minimal_timesteps", &cs::Configuration::minimalTimeSteps,
+                     "Minimal timestep considered for the Clifford synthesis. "
+                     "Defaults to `0`, which implies that the initial timestep "
+                     "limit is determined automatically.")
       .def_readwrite(
           "use_maxsat", &cs::Configuration::useMaxSAT,
           "Use MaxSAT to solve the synthesis problem or to really on the "

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -434,10 +434,14 @@ PYBIND11_MODULE(pyqmap, m) {
                      "Initial timestep limit for the Clifford synthesis. "
                      "Defaults to `0`, which implies that the initial timestep "
                      "limit is determined automatically.")
-      .def_readwrite("minimal_timesteps", &cs::Configuration::minimalTimeSteps,
-                     "Minimal timestep considered for the Clifford synthesis. "
-                     "Defaults to `0`, which implies that the initial timestep "
-                     "limit is determined automatically.")
+      .def_readwrite(
+          "minimal_timesteps", &cs::Configuration::minimalTimeSteps,
+          "Minimal timestep considered for the Clifford synthesis. "
+          "This option limits the lower bound of the interval in "
+          "which the binary search method looks for solutions. "
+          "Set this if you know a lower bound for the circuit depth. "
+          "Defaults to `0`, which implies that no lower bound for depth "
+          "is known.")
       .def_readwrite(
           "use_maxsat", &cs::Configuration::useMaxSAT,
           "Use MaxSAT to solve the synthesis problem or to really on the "

--- a/mqt/qmap/bindings.cpp
+++ b/mqt/qmap/bindings.cpp
@@ -435,7 +435,7 @@ PYBIND11_MODULE(pyqmap, m) {
                      "Defaults to `0`, which implies that the initial timestep "
                      "limit is determined automatically.")
       .def_readwrite(
-          "minimal_timesteps", &cs::Configuration::minimalTimeSteps,
+          "minimal_timesteps", &cs::Configuration::minimalTimesteps,
           "Minimal timestep considered for the Clifford synthesis. "
           "This option limits the lower bound of the interval in "
           "which the binary search method looks for solutions. "

--- a/src/cliffordsynthesis/CliffordSynthesizer.cpp
+++ b/src/cliffordsynthesis/CliffordSynthesizer.cpp
@@ -50,7 +50,7 @@ void CliffordSynthesizer::synthesize(const Configuration& config) {
   // SAT problem repeatedly with increasing timestep limits until a satisfying
   // assignment is found. This uses the general SAT encoding without any
   // objective function regardless of the configuration.
-  auto [lower, upper] = determineUpperBound(encoderConfig);
+  const auto [lower, upper] = determineUpperBound(encoderConfig);
 
   // if the upper bound is 0, the solution does not require any gates and the
   // synthesis is done.
@@ -117,12 +117,14 @@ std::pair<std::size_t, std::size_t>
 CliffordSynthesizer::determineUpperBound(EncoderConfig config) {
   // In case the synthesis was started with a circuit, the upper bound is
   // inherently given by the circuit and does not need to be computed here.
-  if (results.sat()) {
-    return {0U, config.timestepLimit};
-  }
-
+  config.timestepLimit =
+      std::max(config.timestepLimit, config.minimalTimesteps);
   std::size_t lowerBound = config.minimalTimesteps;
   std::size_t upperBound = config.timestepLimit;
+
+  if (results.sat()) {
+    return {lowerBound, upperBound};
+  }
 
   INFO() << "Searching for upper bound for the number of timesteps starting "
          << "with " << upperBound;

--- a/src/cliffordsynthesis/CliffordSynthesizer.cpp
+++ b/src/cliffordsynthesis/CliffordSynthesizer.cpp
@@ -48,8 +48,11 @@ void CliffordSynthesizer::synthesize(const Configuration& config) {
   // SAT problem repeatedly with increasing timestep limits until a satisfying
   // assignment is found. This uses the general SAT encoding without any
   // objective function regardless of the configuration.
-  const auto [lower, upper] = determineUpperBound(encoderConfig);
+  auto [lower, upper] = determineUpperBound(encoderConfig);
 
+  if (lower == 0) {
+    lower = config.minimalTimeSteps;
+  }
   // if the upper bound is 0, the solution does not require any gates and the
   // synthesis is done.
   if (upper == 0U) {
@@ -66,7 +69,7 @@ void CliffordSynthesizer::synthesize(const Configuration& config) {
     gateOptimalSynthesis(encoderConfig, lower, upper);
     break;
   case TargetMetric::Depth:
-    depthOptimalSynthesis(encoderConfig, lower, upper);
+    depthOptimalSynthesis(encoderConfig, config.minimalTimeSteps, upper);
     break;
   case TargetMetric::TwoQubitGates:
     twoQubitGateOptimalSynthesis(encoderConfig, 0U, results.getTwoQubitGates());

--- a/test/cliffordsynthesis/test_synthesis.cpp
+++ b/test/cliffordsynthesis/test_synthesis.cpp
@@ -190,7 +190,7 @@ TEST_P(SynthesisTest, DepthMinimalGates) {
 
 TEST_P(SynthesisTest, DepthMinimalTimeSteps) {
   config.target           = TargetMetric::Depth;
-  config.minimalTimeSteps = test.expectedMinimalDepth;
+  config.minimalTimesteps = test.expectedMinimalDepth;
   synthesizer.synthesize(config);
   results = synthesizer.getResults();
 

--- a/test/cliffordsynthesis/test_synthesis.cpp
+++ b/test/cliffordsynthesis/test_synthesis.cpp
@@ -188,6 +188,15 @@ TEST_P(SynthesisTest, DepthMinimalGates) {
   EXPECT_EQ(results.getGates(), test.expectedMinimalGatesAtMinimalDepth);
 }
 
+TEST_P(SynthesisTest, DepthMinimalTimeSteps) {
+  config.target           = TargetMetric::Depth;
+  config.minimalTimeSteps = test.expectedMinimalDepth;
+  synthesizer.synthesize(config);
+  results = synthesizer.getResults();
+
+  EXPECT_EQ(results.getDepth(), test.expectedMinimalDepth);
+}
+
 TEST_P(SynthesisTest, DepthMinimalGatesMaxSAT) {
   config.target                              = TargetMetric::Depth;
   config.useMaxSAT                           = true;


### PR DESCRIPTION
## Description

This PR adds a setting to the config that allows to set the lower limit for the binary search.

Sometimes a lower bound for the circuit might already be known and one can save on some calls to the Solver by limiting the search space during binary search.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
