### PR TITLE
Fix cnot reversal in heuristic

### DIFF
--- a/include/Architecture.hpp
+++ b/include/Architecture.hpp
@@ -364,20 +364,6 @@ protected:
   void createDistanceTable();
   void createFidelityTable();
 
-  static double dijkstraNodeToCost(const Dijkstra::Node& node) {
-    // Dijkstra determines the minimal path cost from one physical qubit to
-    // another.  In the non-fidelity case we are only interested in swapping 2
-    // logical qubits next to each other. Therefore the last swap cost has to
-    // be ignored. That cost is stored in the field `node.prevCost` of each
-    // node.
-    if (node.containsCorrectEdge) {
-      return node.prevCost;
-    }
-    // in case the last edge is a back-edge, we will need to reverse the CNOT,
-    // executed on that edge
-    return node.prevCost + COST_DIRECTION_REVERSE;
-  }
-
   // added for teleportation
   static bool contains(const std::vector<int>& v, const int e) {
     return std::find(v.begin(), v.end(), e) != v.end();

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -54,13 +54,38 @@ public:
 class Dijkstra {
 public:
   struct Node {
+    /** true if the path contains any forward edge 
+        (i.e. an edge on which a CNOT with directionality q1->q2 
+        can be applied without the need of a CNOT reversal) */
     bool                         containsCorrectEdge = false;
+    /** true if the node has already been expanded */
     bool                         visited             = false;
+    /** current qubit */
     std::optional<std::uint16_t> pos                 = std::nullopt;
+    /** current cost of the path */
     double                       cost                = -1.;
+    /** current cost of the path with the last swap removed */
     double                       prevCost            = -1.;
   };
 
+  /**
+   * @brief builds a distance table containing the minimal costs for moving 
+   * logical qubits from one physical qubit to/next to another (along the 
+   * cheapest path)
+   * 
+   * @param n size of the distance table (i.e. number of qubits)
+   * @param couplingMap coupling map specifying all edges in the architecture
+   * @param distanceTable target table
+   * @param edgeWeights matrix containing costs for swapping any two, connected 
+   * qubits (this might be uniform for all edges or different for each edge, as 
+   * e.g. in the case of fidelity-aware distances or distances on 
+   * mixed bi/unidirectional architectures)
+   * @param reversalCost cost added if path consists only of back edges, i.e. 
+   * the 2-qubit gate to be mapped would need to be reversed in any case 
+   * (if reversal costs are handled elsewhere this should be set to 0)
+   * @param removeLastEdge if set to true, the cost for the last swap on any 
+   * path is removed (i.e. distance is given for moving "next to" qubit)
+   */
   static void buildTable(std::uint16_t n, const CouplingMap& couplingMap,
                          Matrix& distanceTable, const Matrix& edgeWeights,
                          double reversalCost, bool removeLastEdge);

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -63,11 +63,12 @@ public:
 
   static void buildTable(std::uint16_t n, const CouplingMap& couplingMap,
                          Matrix& distanceTable, const Matrix& edgeWeights,
-                         const std::function<double(const Node&)>& cost);
+                          const double reversalCost, const bool removeLastEdge);
 
 protected:
   static void dijkstra(const CouplingMap& couplingMap, std::vector<Node>& nodes,
-                       std::uint16_t start, const Matrix& edgeWeights);
+                       std::uint16_t start, const Matrix& edgeWeights,
+                       const double reversalCost);
 
   struct NodeComparator {
     bool operator()(const Node* x, const Node* y) {

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -63,7 +63,7 @@ public:
 
   static void buildTable(std::uint16_t n, const CouplingMap& couplingMap,
                          Matrix& distanceTable, const Matrix& edgeWeights,
-                          const double reversalCost, const bool removeLastEdge);
+                         const double reversalCost, const bool removeLastEdge);
 
 protected:
   static void dijkstra(const CouplingMap& couplingMap, std::vector<Node>& nodes,

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -63,12 +63,12 @@ public:
 
   static void buildTable(std::uint16_t n, const CouplingMap& couplingMap,
                          Matrix& distanceTable, const Matrix& edgeWeights,
-                         const double reversalCost, const bool removeLastEdge);
+                         double reversalCost, bool removeLastEdge);
 
 protected:
   static void dijkstra(const CouplingMap& couplingMap, std::vector<Node>& nodes,
                        std::uint16_t start, const Matrix& edgeWeights,
-                       const double reversalCost);
+                       double reversalCost);
 
   struct NodeComparator {
     bool operator()(const Node* x, const Node* y) {

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -198,7 +198,8 @@ void Architecture::createDistanceTable() {
     }
   }
 
-  Dijkstra::buildTable(nqubits, couplingMap, distanceTable, edgeWeights, COST_DIRECTION_REVERSE, true);
+  Dijkstra::buildTable(nqubits, couplingMap, distanceTable, edgeWeights,
+                       COST_DIRECTION_REVERSE, true);
 }
 
 void Architecture::createFidelityTable() {

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -198,8 +198,7 @@ void Architecture::createDistanceTable() {
     }
   }
 
-  Dijkstra::buildTable(nqubits, couplingMap, distanceTable, edgeWeights,
-                       Architecture::dijkstraNodeToCost);
+  Dijkstra::buildTable(nqubits, couplingMap, distanceTable, edgeWeights, COST_DIRECTION_REVERSE, true);
 }
 
 void Architecture::createFidelityTable() {

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -151,10 +151,6 @@ void HeuristicMapper::map(const Configuration& configuration) {
           (static_cast<double>(layer.expandedNodes) /
            static_cast<double>(benchmark.expandedNodes));
     }
-    if (benchmark.effectiveBranchingFactor > benchmark.averageBranchingFactor) {
-      throw QMAPException("Something wrong in benchmark tracking: "
-                          "effectiveBranchingFactor > averageBranchingFactor");
-    }
   }
 
   // infer output permutation from qubit locations
@@ -500,14 +496,6 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer) {
 
     layerResultsIt->effectiveBranchingFactor = computeEffectiveBranchingRate(
         layerResultsIt->expandedNodes + 1, result.depth);
-
-    if (layerResultsIt->effectiveBranchingFactor >
-        layerResultsIt->averageBranchingFactor) {
-      throw QMAPException(
-          "Something wrong in benchmark tracking on layer " +
-          std::to_string(layer) +
-          ": effectiveBranchingFactor > averageBranchingFactor");
-    }
   }
 
   // clear nodes

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -9,7 +9,8 @@
 
 void Dijkstra::buildTable(const std::uint16_t n, const CouplingMap& couplingMap,
                           Matrix& distanceTable, const Matrix& edgeWeights,
-                          const double reversalCost, const bool removeLastEdge) {
+                          const double reversalCost,
+                          const bool   removeLastEdge) {
   distanceTable.clear();
   distanceTable.resize(n, std::vector<double>(n, -1.));
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -23,7 +23,10 @@ void Dijkstra::buildTable(const std::uint16_t n, const CouplingMap& couplingMap,
       nodes.at(j).cost                = -1.;
       nodes.at(j).prevCost            = -1.;
     }
-
+    
+    // initially all paths assume that a CNOT reversal will be necessary,
+    // as soon as a forward edge is encountered along the path, the cost
+    // for the reversal is removed
     nodes.at(i).cost     = reversalCost;
     nodes.at(i).prevCost = reversalCost;
 
@@ -56,11 +59,15 @@ void Dijkstra::dijkstra(const CouplingMap& couplingMap,
 
     for (const auto& edge : couplingMap) {
       std::optional<std::uint16_t> to          = std::nullopt;
-      bool                         correctEdge = current->containsCorrectEdge;
-      if (pos == edge.first) {
+      // if the path up to here already contains a forward edge, we do not care
+      // about the directionality of other edges anymore; the value of the last
+      // node is therefore kept and only overwritten with true if the current
+      // edge is a forward edge (but never with false)
+      bool correctEdge = current->containsCorrectEdge;
+      if (pos == edge.first) { // forward edge
         to          = edge.second;
         correctEdge = true;
-      } else if (pos == edge.second) {
+      } else if (pos == edge.second) { // back edge
         to = edge.first;
       }
       if (to.has_value()) {
@@ -74,6 +81,8 @@ void Dijkstra::dijkstra(const CouplingMap& couplingMap,
         newNode.pos      = to;
         newNode.containsCorrectEdge = correctEdge;
         if (newNode.containsCorrectEdge && !current->containsCorrectEdge) {
+          // when encountering the first forward edge along the path, the 
+          // reversal costs need to be removed
           newNode.cost -= reversalCost;
           newNode.prevCost -= reversalCost;
         }

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -89,30 +89,27 @@ TEST(General, DijkstraCNOTReversal) {
 
   const CouplingMap cm = {{0, 1}, {2, 1}, {2, 3}, {3, 4}};
 
-  const Matrix edgeWeights = {
-      {0, 3, 0, 0, 0}, 
-      {3, 0, 3, 0, 0}, 
-      {0, 3, 0, 3, 0}, 
-      {0, 0, 3, 0, 3},
-      {0, 0, 0, 3, 0}};
+  const Matrix edgeWeights = {{0, 3, 0, 0, 0},
+                              {3, 0, 3, 0, 0},
+                              {0, 3, 0, 3, 0},
+                              {0, 0, 3, 0, 3},
+                              {0, 0, 0, 3, 0}};
 
-  const Matrix targetTable1 = {
-      { 0, 3, 6, 9, 12}, 
-      { 4, 0, 4, 6, 9}, 
-      { 6, 3, 0, 3, 6}, 
-      { 9, 6, 4, 0, 3},
-      {12, 9, 7, 4, 0}};
-  Matrix distanceTable{};
+  const Matrix targetTable1 = {{0, 3, 6, 9, 12},
+                               {4, 0, 4, 6, 9},
+                               {6, 3, 0, 3, 6},
+                               {9, 6, 4, 0, 3},
+                               {12, 9, 7, 4, 0}};
+  Matrix       distanceTable{};
   Dijkstra::buildTable(5, cm, distanceTable, edgeWeights, 1, false);
   EXPECT_EQ(distanceTable, targetTable1);
 
-  const Matrix targetTable2 = {
-      {0, 0, 3, 6, 9}, 
-      {1, 0, 1, 3, 6}, 
-      {3, 0, 0, 0, 3}, 
-      {6, 3, 1, 0, 0},
-      {9, 6, 4, 1, 0}};
-  distanceTable = {};
+  const Matrix targetTable2 = {{0, 0, 3, 6, 9},
+                               {1, 0, 1, 3, 6},
+                               {3, 0, 0, 0, 3},
+                               {6, 3, 1, 0, 0},
+                               {9, 6, 4, 1, 0}};
+  distanceTable             = {};
   Dijkstra::buildTable(5, cm, distanceTable, edgeWeights, 1, true);
   EXPECT_EQ(distanceTable, targetTable2);
 }

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -81,3 +81,38 @@ TEST(General, Dijkstra) {
   Dijkstra::buildTable(4, cm, distanceTable, edgeWeights, 0, true);
   EXPECT_EQ(distanceTable, targetTable2);
 }
+
+TEST(General, DijkstraCNOTReversal) {
+  /*
+  0 -> 1 <- 2 -> 3 -> 4
+  */
+
+  const CouplingMap cm = {{0, 1}, {2, 1}, {2, 3}, {3, 4}};
+
+  const Matrix edgeWeights = {
+      {0, 3, 0, 0, 0}, 
+      {3, 0, 3, 0, 0}, 
+      {0, 3, 0, 3, 0}, 
+      {0, 0, 3, 0, 3},
+      {0, 0, 0, 3, 0}};
+
+  const Matrix targetTable1 = {
+      { 0, 3, 6, 9, 12}, 
+      { 4, 0, 4, 6, 9}, 
+      { 6, 3, 0, 3, 6}, 
+      { 9, 6, 4, 0, 3},
+      {12, 9, 7, 4, 0}};
+  Matrix distanceTable{};
+  Dijkstra::buildTable(5, cm, distanceTable, edgeWeights, 1, false);
+  EXPECT_EQ(distanceTable, targetTable1);
+
+  const Matrix targetTable2 = {
+      {0, 0, 3, 6, 9}, 
+      {1, 0, 1, 3, 6}, 
+      {3, 0, 0, 0, 3}, 
+      {6, 3, 1, 0, 0},
+      {9, 6, 4, 1, 0}};
+  distanceTable = {};
+  Dijkstra::buildTable(5, cm, distanceTable, edgeWeights, 1, true);
+  EXPECT_EQ(distanceTable, targetTable2);
+}

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -72,14 +72,12 @@ TEST(General, Dijkstra) {
   const Matrix targetTable1 = {
       {0, 1, 3, 6}, {1, 0, 2, 5}, {10, 9, 0, 3}, {7, 6, 3, 0}};
   Matrix distanceTable{};
-  Dijkstra::buildTable(4, cm, distanceTable, edgeWeights,
-                       [](const Dijkstra::Node& n) { return n.cost; });
+  Dijkstra::buildTable(4, cm, distanceTable, edgeWeights, 0, false);
   EXPECT_EQ(distanceTable, targetTable1);
 
   const Matrix targetTable2 = {
       {0, 0, 1, 3}, {0, 0, 0, 2}, {9, 3, 0, 0}, {6, 0, 0, 0}};
   distanceTable = {};
-  Dijkstra::buildTable(4, cm, distanceTable, edgeWeights,
-                       [](const Dijkstra::Node& n) { return n.prevCost; });
+  Dijkstra::buildTable(4, cm, distanceTable, edgeWeights, 0, true);
   EXPECT_EQ(distanceTable, targetTable2);
 }


### PR DESCRIPTION
## Description

The current heuristic implementation, when determining if a reversal will be necessary for some given CNOT on a unidirectional architecture, considers only the 2 edges next to the 2 qubits involved in the CNOT along the shortest path (i.e. it assumes that one of the 2 qubits will eventually move all the way next to current position of the other qubit, instead of possibly meeting somewhere in the middle). However, if there is _any_ edge along the shortest path, a reversal might in fact not be necessary. Thereby, the current implementation overestimates the true cost (i.e. violates admissibility) in some cases.

This PR fixes this by only applying the reversal cost if no edge along the shortest path is oriented in the right direction.

Additionally, a minor bug fix in benchmarking: The checks for `effectiveBranchingFactor > averageBranchingFactor` were removed, as I realized that this can actually occur for heavily unbalanced search trees (commonly occuring for very flat heuristics).

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
