### PR TITLE
Move `admissible_heuristic` and `consider_fidelity` in JSON of `Configuration`

### DIFF
--- a/src/configuration/Configuration.cpp
+++ b/src/configuration/Configuration.cpp
@@ -21,10 +21,10 @@ nlohmann::json Configuration::json() const {
   if (method == Method::Heuristic) {
     auto& heuristic             = config["settings"];
     heuristic["initial_layout"] = ::toString(initialLayout);
+    heuristic["admissible_heuristic"] = admissibleHeuristic;
+    heuristic["consider_fidelity"]    = considerFidelity;
     if (lookahead) {
       auto& lookaheadSettings                   = heuristic["lookahead"];
-      lookaheadSettings["admissible_heuristic"] = admissibleHeuristic;
-      lookaheadSettings["consider_fidelity"]    = considerFidelity;
       lookaheadSettings["lookaheads"]           = nrLookaheads;
       lookaheadSettings["first_factor"]         = firstLookaheadFactor;
       lookaheadSettings["factor"]               = lookaheadFactor;

--- a/src/configuration/Configuration.cpp
+++ b/src/configuration/Configuration.cpp
@@ -19,15 +19,15 @@ nlohmann::json Configuration::json() const {
   config["debug"]                              = debug;
 
   if (method == Method::Heuristic) {
-    auto& heuristic             = config["settings"];
-    heuristic["initial_layout"] = ::toString(initialLayout);
+    auto& heuristic                   = config["settings"];
+    heuristic["initial_layout"]       = ::toString(initialLayout);
     heuristic["admissible_heuristic"] = admissibleHeuristic;
     heuristic["consider_fidelity"]    = considerFidelity;
     if (lookahead) {
-      auto& lookaheadSettings                   = heuristic["lookahead"];
-      lookaheadSettings["lookaheads"]           = nrLookaheads;
-      lookaheadSettings["first_factor"]         = firstLookaheadFactor;
-      lookaheadSettings["factor"]               = lookaheadFactor;
+      auto& lookaheadSettings           = heuristic["lookahead"];
+      lookaheadSettings["lookaheads"]   = nrLookaheads;
+      lookaheadSettings["first_factor"] = firstLookaheadFactor;
+      lookaheadSettings["factor"]       = lookaheadFactor;
     }
     if (useTeleportation) {
       auto& teleportation     = heuristic["teleportation"];


### PR DESCRIPTION
## Description

Moving `admissible_heuristic` and `consider_fidelity` in the JSON representation of `Configuration` from `config.settings.lookahead` to `config.settings`.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
